### PR TITLE
Use new provider interface

### DIFF
--- a/qiskit/providers/aqt/aqt_backend.py
+++ b/qiskit/providers/aqt/aqt_backend.py
@@ -12,15 +12,22 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+import warnings
+
 import requests
 
-from qiskit.providers import BaseBackend
+from qiskit import qobj as qobj_mod
+from qiskit.providers import BackendV1 as Backend
+from qiskit.providers import Options
 from qiskit.providers.models import BackendConfiguration
+from qiskit.exceptions import QiskitError
+
 from . import aqt_job
 from . import qobj_to_aqt
+from . import circuit_to_aqt
 
 
-class AQTSimulator(BaseBackend):
+class AQTSimulator(Backend):
 
     def __init__(self, provider):
         self.url = "https://gateway.aqt.eu/marmot/sim/"
@@ -51,16 +58,36 @@ class AQTSimulator(BaseBackend):
             configuration=BackendConfiguration.from_dict(configuration),
             provider=provider)
 
-    def run(self, qobj):
-        if qobj.config.shots > self.configuration().max_shots:
-            raise ValueError('Number of shots is larger than maximum '
-                             'number of shots')
-        aqt_json = qobj_to_aqt.qobj_to_aqt(
-            qobj, self._provider.access_token)[0]
+    @classmethod
+    def _default_options(cls):
+        return Options(shots=100)
+
+    def run(self, qobj, **kwargs):
+        if isinstance(qobj, qobj_mod.QasmQobj):
+            warnings.warn("Passing in a QASMQobj object to run() is "
+                          "deprecated and will be removed in a future "
+                          "release", DeprecationWarning)
+            if qobj.config.shots > self.configuration().max_shots:
+                raise ValueError('Number of shots is larger than maximum '
+                                 'number of shots')
+            aqt_json = qobj_to_aqt.qobj_to_aqt(
+                qobj, self._provider.access_token)[0]
+        elif isinstance(qobj, qobj_mod.PulseQobj):
+            raise QiskitError("Pulse jobs are not accepted")
+        else:
+            for kwarg in kwargs:
+                if kwarg != 'shots':
+                    warnings.warn(
+                        "Option %s is not used by this backend" % kwarg,
+                        UserWarning)
+            out_shots = kwargs.get('shots', self.options.shots)
+            aqt_json = circuit_to_aqt.circuit_to_aqt(
+                qobj, self._provider.access_token, shots=out_shots)[0]
         header = {
             "Ocp-Apim-Subscription-Key": self._provider.access_token,
             "SDK": "qiskit"
         }
+        print(aqt_json)
         res = requests.put(self.url, data=aqt_json, headers=header)
         res.raise_for_status()
         response = res.json()
@@ -70,7 +97,7 @@ class AQTSimulator(BaseBackend):
         return job
 
 
-class AQTSimulatorNoise1(BaseBackend):
+class AQTSimulatorNoise1(Backend):
 
     def __init__(self, provider):
         self.url = "https://gateway.aqt.eu/marmot/sim/noise-model-1"
@@ -102,12 +129,31 @@ class AQTSimulatorNoise1(BaseBackend):
             configuration=BackendConfiguration.from_dict(configuration),
             provider=provider)
 
-    def run(self, qobj):
-        if qobj.config.shots > self.configuration().max_shots:
-            raise ValueError('Number of shots is larger than maximum '
-                             'number of shots')
-        aqt_json = qobj_to_aqt.qobj_to_aqt(
-            qobj, self._provider.access_token)[0]
+    @classmethod
+    def _default_options(cls):
+        return Options(shots=100)
+
+    def run(self, qobj, **kwargs):
+        if isinstance(qobj, qobj_mod.QasmQobj):
+            warnings.warn("Passing in a QASMQobj object to run() is "
+                          "deprecated and will be removed in a future "
+                          "release", DeprecationWarning)
+            if qobj.config.shots > self.configuration().max_shots:
+                raise ValueError('Number of shots is larger than maximum '
+                                 'number of shots')
+            aqt_json = qobj_to_aqt.qobj_to_aqt(
+                qobj, self._provider.access_token)[0]
+        elif isinstance(qobj, qobj_mod.PulseQobj):
+            raise QiskitError("Pulse jobs are not accepted")
+        else:
+            for kwarg in kwargs:
+                if kwarg != 'shots':
+                    warnings.warn(
+                        "Option %s is not used by this backend" % kwarg,
+                        UserWarning)
+            out_shots = kwargs.get('shots', self.options.shots)
+            aqt_json = circuit_to_aqt.circuit_to_aqt(
+                qobj, self._provider.access_token, shots=out_shots)[0]
         header = {
             "Ocp-Apim-Subscription-Key": self._provider.access_token,
             "SDK": "qiskit"
@@ -121,7 +167,7 @@ class AQTSimulatorNoise1(BaseBackend):
         return job
 
 
-class AQTDevice(BaseBackend):
+class AQTDevice(Backend):
 
     def __init__(self, provider):
         self.url = 'https://gateway.aqt.eu/marmot/lint'
@@ -152,12 +198,31 @@ class AQTDevice(BaseBackend):
             configuration=BackendConfiguration.from_dict(configuration),
             provider=provider)
 
-    def run(self, qobj):
-        if qobj.config.shots > self.configuration().max_shots:
-            raise ValueError('Number of shots is larger than maximum '
-                             'number of shots')
-        aqt_json = qobj_to_aqt.qobj_to_aqt(
-            qobj, self._provider.access_token)[0]
+    @classmethod
+    def _default_options(cls):
+        return Options(shots=100)
+
+    def run(self, qobj, **kwargs):
+        if isinstance(qobj, qobj_mod.QasmQobj):
+            warnings.warn("Passing in a QASMQobj object to run() is "
+                          "deprecated and will be removed in a future "
+                          "release", DeprecationWarning)
+            if qobj.config.shots > self.configuration().max_shots:
+                raise ValueError('Number of shots is larger than maximum '
+                                 'number of shots')
+            aqt_json = qobj_to_aqt.qobj_to_aqt(
+                qobj, self._provider.access_token)[0]
+        elif isinstance(qobj, qobj_mod.PulseQobj):
+            raise QiskitError("Pulse jobs are not accepted")
+        else:
+            for kwarg in kwargs:
+                if kwarg != 'shots':
+                    warnings.warn(
+                        "Option %s is not used by this backend" % kwarg,
+                        UserWarning)
+            out_shots = kwargs.get('shots', self.options.shots)
+            aqt_json = circuit_to_aqt.circuit_to_aqt(
+                qobj, self._provider.access_token, shots=out_shots)[0]
         header = {
             "Ocp-Apim-Subscription-Key": self._provider.access_token,
             "SDK": "qiskit"

--- a/qiskit/providers/aqt/aqt_backend.py
+++ b/qiskit/providers/aqt/aqt_backend.py
@@ -79,7 +79,7 @@ class AQTSimulator(Backend):
                 if kwarg != 'shots':
                     warnings.warn(
                         "Option %s is not used by this backend" % kwarg,
-                        UserWarning)
+                        UserWarning, stacklevel=2)
             out_shots = kwargs.get('shots', self.options.shots)
             aqt_json = circuit_to_aqt.circuit_to_aqt(
                 qobj, self._provider.access_token, shots=out_shots)[0]
@@ -87,7 +87,6 @@ class AQTSimulator(Backend):
             "Ocp-Apim-Subscription-Key": self._provider.access_token,
             "SDK": "qiskit"
         }
-        print(aqt_json)
         res = requests.put(self.url, data=aqt_json, headers=header)
         res.raise_for_status()
         response = res.json()
@@ -150,7 +149,7 @@ class AQTSimulatorNoise1(Backend):
                 if kwarg != 'shots':
                     warnings.warn(
                         "Option %s is not used by this backend" % kwarg,
-                        UserWarning)
+                        UserWarning, stacklevel=2)
             out_shots = kwargs.get('shots', self.options.shots)
             aqt_json = circuit_to_aqt.circuit_to_aqt(
                 qobj, self._provider.access_token, shots=out_shots)[0]
@@ -219,7 +218,7 @@ class AQTDevice(Backend):
                 if kwarg != 'shots':
                     warnings.warn(
                         "Option %s is not used by this backend" % kwarg,
-                        UserWarning)
+                        UserWarning, stacklevel=2)
             out_shots = kwargs.get('shots', self.options.shots)
             aqt_json = circuit_to_aqt.circuit_to_aqt(
                 qobj, self._provider.access_token, shots=out_shots)[0]

--- a/qiskit/providers/aqt/aqt_provider.py
+++ b/qiskit/providers/aqt/aqt_provider.py
@@ -14,12 +14,12 @@
 
 
 from qiskit.providers.providerutils import filter_backends
-from qiskit.providers import BaseProvider
+from qiskit.providers import ProviderV1 as Provider
 
 from .aqt_backend import AQTSimulator, AQTSimulatorNoise1, AQTDevice
 
 
-class AQTProvider(BaseProvider):
+class AQTProvider(Provider):
     """Provider for backends from Alpine Quantum Technologies (AQT)."""
 
     def __init__(self, access_token):

--- a/qiskit/providers/aqt/circuit_to_aqt.py
+++ b/qiskit/providers/aqt/circuit_to_aqt.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import json
+
+from numpy import pi
+
+
+def _experiment_to_seq(circuit):
+    count = 0
+    qubit_map = {}
+    for bit in circuit.qubits:
+        qubit_map[bit] = count
+        count += 1
+    ops = []
+    meas = 0
+    for instruction in circuit.data:
+        inst = instruction[0]
+        qubits = [qubit_map[bit] for bit in instruction[1]]
+        if inst.name == 'rx':
+            name = 'X'
+        elif inst.name == 'ry':
+            name = 'Y'
+        elif inst.name == 'rxx':
+            name = 'MS'
+        elif inst.name == 'ms':
+            name = 'MS'
+            qubits = []
+        elif inst.name == 'measure':
+            meas += 1
+            continue
+        elif inst.name == 'barrier':
+            continue
+        else:
+            raise Exception("Operation '%s' outside of basis rx, ry, rxx" %
+                            inst.name)
+        exponent = inst.params[0] / pi
+        # hack: split X into X**0.5 . X**0.5
+        if name == 'X' and exponent == 1.0:
+            ops.append((name, float(0.5), qubits))
+            ops.append((name, float(0.5), qubits))
+        else:
+            # (op name, exponent, [qubit index])
+            ops.append((name, float(exponent), qubits))
+    if not meas:
+        raise ValueError('Circuit must have at least one measurements.')
+    return json.dumps(ops)
+
+
+def circuit_to_aqt(circuits, access_token, shots=100):
+    """Return a list of json payload strings for each experiment in a qobj
+
+    The output json format of an experiment is defined as follows:
+        [[op_string, gate_exponent, qubits]]
+
+    which is a list of sequential quantum operations, each operation defined
+    by:
+
+    op_string: str that specifies the operation type, either "X","Y","MS"
+    gate_exponent: float that specifies the gate_exponent of the operation
+    qubits: list of qubits where the operation acts on.
+    """
+    out_json = []
+    if isinstance(circuits, list):
+        if len(circuits) > 1:
+            raise Exception
+        circuits = circuits[0]
+    seqs = _experiment_to_seq(circuits)
+    out_dict = {
+        'data': seqs,
+        'access_token': access_token,
+        'repetitions': shots,
+        'no_qubits': circuits.num_qubits,
+    }
+    out_json.append(out_dict)
+    return out_json

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ import sys
 requirements = [
     "requests>=2.19",
     "setuptools>=40.1.0",
-    "qiskit-terra>=0.10.0",
+    "qiskit-terra>=0.16.0",
 ]
 
 

--- a/test/test_circuit_to_aqt.py
+++ b/test/test_circuit_to_aqt.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import unittest
+
+from numpy import pi
+from qiskit import QuantumCircuit
+
+from qiskit.providers.aqt.circuit_to_aqt import circuit_to_aqt
+
+
+class TestCircuitToAQT(unittest.TestCase):
+
+    def test_empty_circuit(self):
+        qc = QuantumCircuit(1)
+        self.assertRaises(ValueError, circuit_to_aqt, qc, 'foo')
+
+    def test_just_measure_circuit(self):
+        qc = QuantumCircuit(1, 1)
+        qc.measure(0, 0)
+        aqt_json = circuit_to_aqt(qc, 'foo')
+        self.assertEqual(
+            [{'access_token': 'foo', 'data': '[]', 'no_qubits': 1,
+              'repetitions': 100}], aqt_json)
+
+    def test_invalid_basis_in_circuit(self):
+        qc = QuantumCircuit(1, 1)
+        qc.h(0)
+        qc.measure(0, 0)
+        self.assertRaises(Exception, circuit_to_aqt, qc, 'foo')
+
+    def test_with_single_rx(self):
+        qc = QuantumCircuit(1, 1)
+        qc.rx(pi, 0)
+        qc.measure(0, 0)
+        expected = [{'access_token': 'foo',
+                     'data': '[["X", 0.5, [0]], ["X", 0.5, [0]]]',
+                     'no_qubits': 1,
+                     'repetitions': 100}]
+        self.assertEqual(expected, circuit_to_aqt(qc, 'foo'))
+
+    def test_with_two_rx(self):
+        qc = QuantumCircuit(1, 1)
+        qc.rx(pi, 0)
+        qc.rx(2*pi, 0)
+        qc.measure(0, 0)
+        expected = [{'access_token': 'foo',
+                     'data': '[["X", 0.5, [0]], ["X", 0.5, [0]], '
+                             '["X", 2.0, [0]]]',
+                     'no_qubits': 1,
+                     'repetitions': 100}]
+        self.assertEqual(expected, circuit_to_aqt(qc, 'foo'))
+
+    def test_with_single_ry(self):
+        qc = QuantumCircuit(1, 1)
+        qc.ry(pi, 0)
+        qc.measure(0, 0)
+        expected = [{'access_token': 'foo',
+                     'data': '[["Y", 1.0, [0]]]',
+                     'no_qubits': 1,
+                     'repetitions': 100}]
+        self.assertEqual(expected, circuit_to_aqt(qc, 'foo'))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In qiskit-terra 0.16.0 a new version of the provider interface was
added. This version is now explicitly versioned to enable graceful
changes to the interface over time. For the first version of this new
interface the key changes are that circuits can be passed directly to
Backend.run() and to go along with that a new options object has been
added to the backend to track run time options for a backend. This
commit updates the internal aqt provider interface to use the new
version instead of the previous legacy providers interface.

### Details and comments