### PR TITLE
Drop Python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: false
 matrix:
   fast_finish: true
   include:
-    - python: "3.5"
-      env: TOXENV=py35
     - python: "3.6"
       env: TOXENV=py36
     - python: 3.7

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,10 +11,6 @@ jobs:
   - job: 'Windows_Testing'
     strategy:
       matrix:
-        Python35:
-          python.version: '3.5'
-          TOXENV: py35
-          imageName: "vs2017-win2016"
         Python36:
           python.version: '3.6'
           TOXENV: py36
@@ -43,9 +39,6 @@ jobs:
   - job: 'macOS_Testing'
     strategy:
       matrix:
-        Python35:
-          python.version: '3.5'
-          TOXENV: py35
         Python36:
           python.version: '3.6'
           TOXENV: py36

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ setuptools.setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
@@ -75,7 +74,7 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(exclude=['test*']),
     install_requires=requirements,
     include_package_data=True,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     project_urls={
         "Bug Tracker": "https://github.com/qiskit-community/qiskit-aqt-provider/issues",
         "Source Code": "https://github.com/qiskit-community/qiskit-aqt-provider",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Python 3.5 went EoL in September of this year and the from the
Qiskit Terra 0.16.0 release onwards Python 3.5 is no longer supported in
terra. Since future work on the aqt provider will depend on newer
versions of Qiskit Terra we need to be able to use the later versions of
Terra. This commit drops support for python 3.5 from the aqt provider,
from this point onwards python 3.6 will be the minimum version of python
that works.

### Details and comments


