### PR TITLE
Emit a single warning about pending package namespace change

### DIFF
--- a/qiskit/providers/aqt/__init__.py
+++ b/qiskit/providers/aqt/__init__.py
@@ -1,5 +1,30 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import warnings
+
 from .aqt_account import AQTAccount
 from . import version
 
+_PACKAGING_WARNING = False
+
 AQT = AQTAccount()
 __version__ = version.__version__
+
+if not _PACKAGING_WARNING:
+    warnings.warn("The qiskit.providers.aqt package will be renamed in the "
+                  "next release. Starting in qiskit-aqt-provider 0.4.0 you "
+                  "will need to change imports from 'qiskit.providers.aqt' to "
+                  "'qiskit_aqt_provider'.", DeprecationWarning, stacklevel=2)
+    _PACKAGING_WARNING = True


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In the release after next, 0.4.0, we will change the namespace of the
package from 'qiskit.providers.aqt' to 'qiskit_aqt_provider'. This is
being done for 2 reasons. The first is to make it clear what is developed
as part of the core qiskit project, and things on top of it. The second
is that python namespace packaging is quite error prone and a frequent
cause of user issues. So having the aqt provider package own its own
namespace should make it much more reliable to install and use. (see
Qiskit/qiskit#559 for more details). While the first reason may change
over time as the priorities and objective of the Qiskit project evolve,
the second will always remain true. So even if the first goes away this
will be a one way permanent change.

### Details and comments