### PR TITLE
Fix docs artifact upload path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,4 +80,4 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: html_docs
-          path: docs/_build/html
+          path: docs/_build

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/jupyter_execute
 
 # PyBuilder
 target/


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #40 the ci configuration was changed to use github actions, part of
what that offers is an artifact store where we can upload the built docs
for download to check the output. However there was a typo in that job
configuration and it trying to upload the incorrect path. This commit
corrects that oversight so that we will upload the built docs at the end
of every docs job.

### Details and comments