### PR TITLE
Set HTML title for docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,7 @@ extensions = [
 
 html_theme = "qiskit-ecosystem"
 pygments_style = "emacs"
+html_title = f"{project} {release}"
 
 # --------------------
 # General options


### PR DESCRIPTION
This makes it so the left side bar doesn't include the word "documentation" in the site title.
