### PR TITLE
docs: add guide and API reference on primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Check that the circuits submitted to the offline simulators can be converted to the AQT API (#68)
-* Update the user guide and improve the API reference consistency (#72)
+* Update the user guide and improve the API reference consistency (#72, #75)
 * Add quickstart examples for the Qiskit.org homepage (#73)
 
 ## qiskit-aqt-provider v0.17.0

--- a/docs/apidoc/primitives.rst
+++ b/docs/apidoc/primitives.rst
@@ -1,0 +1,13 @@
+.. _qiskit-aqt-primitives:
+
+=================
+Qiskit primitives
+=================
+
+.. autoclass:: qiskit_aqt_provider.primitives.sampler.AQTSampler
+   :show-inheritance:
+   :exclude-members: __new__
+
+.. autoclass:: qiskit_aqt_provider.primitives.estimator.AQTEstimator
+   :show-inheritance:
+   :exclude-members: __new__

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,20 +20,21 @@ Define a circuit that generates 2-qubit Bell state and sample it on a simulator 
    from qiskit_aqt_provider import AQTProvider
    from qiskit_aqt_provider.primitives import AQTSampler
 
-   # Define a circuit
+   # Define a circuit.
    circuit = QuantumCircuit(2)
    circuit.h(0)
    circuit.cnot(0, 1)
    circuit.measure_all()
 
-   # Select an execution backend
+   # Select an execution backend.
+   # Any token (even invalid ones) give access to the offline simulation backends.
    provider = AQTProvider("ACCESS_TOKEN")
    backend = provider.get_backend("offline_simulator_no_noise")
 
-   # Instantiate a sampler on the execution backend
+   # Instantiate a sampler on the execution backend.
    sampler = AQTSampler(backend)
 
-   # Sample the circuit on the execution backend
+   # Sample the circuit on the execution backend.
    result = sampler.run(circuit).result()
 
    quasi_dist = result.quasi_dists[0]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,24 +11,33 @@ hardware.
 Quick start
 -----------
 
-Define a circuit that generates 2-qubit Bell state and execute it on a simulator backend:
+Define a circuit that generates 2-qubit Bell state and sample it on a simulator backend running on the local machine:
 
 .. jupyter-execute::
 
-   import qiskit
    from qiskit import QuantumCircuit
+
    from qiskit_aqt_provider import AQTProvider
+   from qiskit_aqt_provider.primitives import AQTSampler
 
-   backend = AQTProvider("ACCESS_TOKEN").get_backend("offline_simulator_no_noise")
+   # Define a circuit
+   circuit = QuantumCircuit(2)
+   circuit.h(0)
+   circuit.cnot(0, 1)
+   circuit.measure_all()
 
-   qc = QuantumCircuit(2)
-   qc.h(0)
-   qc.cnot(0, 1)
-   qc.measure_all()
+   # Select an execution backend
+   provider = AQTProvider("ACCESS_TOKEN")
+   backend = provider.get_backend("offline_simulator_no_noise")
 
-   result = qiskit.execute(qc, backend, with_progress_bar=False).result()
-   print(result.get_counts())
+   # Instantiate a sampler on the execution backend
+   sampler = AQTSampler(backend)
 
+   # Sample the circuit on the execution backend
+   result = sampler.run(circuit).result()
+
+   quasi_dist = result.quasi_dists[0]
+   print(quasi_dist)
 
 For more details see the :ref:`user guide <user-guide>`, a selection of `examples <https://github.com/qiskit-community/qiskit-aqt-provider/tree/master/examples>`_, or the API reference.
 
@@ -48,4 +57,5 @@ For more details see the :ref:`user guide <user-guide>`, a selection of `example
   AQTResource <apidoc/resource>
   AQTJob <apidoc/job>
   AQTOptions <apidoc/options>
+  Qiskit primitives <apidoc/primitives>
   Transpiler plugin <apidoc/transpiler_plugin>

--- a/qiskit_aqt_provider/primitives/estimator.py
+++ b/qiskit_aqt_provider/primitives/estimator.py
@@ -20,7 +20,7 @@ from qiskit_aqt_provider.aqt_resource import AQTResource, make_transpiler_target
 
 
 class AQTEstimator(BackendEstimator):
-    """Estimator primitive for AQT backends."""
+    """:class:`Estimator <qiskit.primitives.Estimator>` primitive for AQT backends."""
 
     _backend: AQTResource
 
@@ -31,13 +31,15 @@ class AQTEstimator(BackendEstimator):
         abelian_grouping: bool = True,
         skip_transpilation: bool = False,
     ):
-        """Initialize an Estimator primitive for AQT resources.
+        """Initialize an ``Estimator`` primitive using an AQT backend.
 
         Args:
-            backend: AQT resource to evaluate circuits on
-            options: options passed to the base sampler
-            abelian_grouping:  whether the observable should be grouped into commuting parts
-            skip_transpilation: if true, pass circuits unchanged to the backend.
+            backend: AQT resource to evaluate circuits on.
+            options: options passed to through to the underlying
+              :class:`BackendEstimator <qiskit.primitives.BackendEstimator>`.
+            abelian_grouping:  whether the observable should be grouped into commuting parts.
+            skip_transpilation: if :data:`True`, do not transpile circuits
+              before passing them to the execution backend.
         """
         # Signal the transpiler to disable passes that require bound
         # parameters.

--- a/qiskit_aqt_provider/primitives/sampler.py
+++ b/qiskit_aqt_provider/primitives/sampler.py
@@ -20,7 +20,7 @@ from qiskit_aqt_provider.aqt_resource import AQTResource, make_transpiler_target
 
 
 class AQTSampler(BackendSampler):
-    """Sampler primitive for AQT backends."""
+    """:class:`Sampler <qiskit.primitives.Sampler>` primitive for AQT backends."""
 
     _backend: AQTResource
 
@@ -30,12 +30,14 @@ class AQTSampler(BackendSampler):
         options: Optional[Dict[str, Any]] = None,
         skip_transpilation: bool = False,
     ):
-        """Initialize a Sampler primitive for AQT resources.
+        """Initialize a ``Sampler`` primitive using an AQT backend.
 
         Args:
-            backend: AQT resource to evaluate circuits on
-            options: options passed to the base sampler
-            skip_transpilation: if true, pass circuits unchanged to the backend.
+            backend: AQT resource to evaluate circuits on.
+            options: options passed through to the underlying
+              :class:`BackendSampler <qiskit.primitives.BackendSampler>`.
+            skip_transpilation: if :data:`True`, do not transpile circuits
+              before passing them to the execution backend.
         """
         # Signal the transpiler to disable passes that require bound
         # parameters.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This patch expands the documentation to cover the specialized Qiskit primitives implementations `AQTSampler` and `AQTEstimator`.

Added:
- API reference
- user guide paragraph in the circuit evaluation section
- user guide paragraph in the transpilation section, to point out the issues with caching using the AQT transpiler plugin.

Modified:
- the quick start example on the documentation landing page now uses a more modern approach for Qiskit, with a `Sampler` rather than direct circuit execution.
