### PR TITLE
workflows/release: use PyPI trusted publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ jobs:
   wheel-build:
     name: Build and Publish Release Artifacts
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -19,7 +22,7 @@ jobs:
         with:
           poetry-version: '1.5.1'
       - name: Install release dependencies
-        run: pip install -U twine wheel typer mistletoe
+        run: pip install -U typer mistletoe
       - name: Build packages
         run: |
           poetry build
@@ -36,7 +39,4 @@ jobs:
           files: ./dist/qiskit*
           body_path: ${{ github.workspace }}-CHANGELOG.txt
       - name: Publish to PyPI
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: qiskit
-        run: twine upload dist/qiskit*
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Resolves #86.

@mtreinish could you please add this repository as a trusted publisher for [qiskit-aqt-provider](https://pypi.org/project/qiskit-aqt-provider/)? or, better, add the [aqt-admin](https://pypi.org/user/aqt-admin/) as co-maintainer of the project, such that we can administrate the PyPI project directly? Thanks!
