### PR TITLE
provider/backends: make string filters match exactly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Interprete string filters in `AQTProvider.get_backend()` as exact matches, not patterns (#90)
+
 ## qiskit-aqt-provider v0.18.0
 
 * Check that the circuits submitted to the offline simulators can be converted to the AQT API (#68)

--- a/qiskit_aqt_provider/api_models.py
+++ b/qiskit_aqt_provider/api_models.py
@@ -74,7 +74,6 @@ class Workspaces(pdt.BaseModel, extra=pdt.Extra.forbid, frozen=True):
     ) -> Self:
         """Filtered copy of the list of available workspaces and devices.
 
-        All regular expression matches are case insensitive.
         Omitted criteria match any entry in the respective field.
 
         Args:
@@ -87,9 +86,7 @@ class Workspaces(pdt.BaseModel, extra=pdt.Extra.forbid, frozen=True):
         """
         filtered_workspaces = []
         for workspace in self.__root__:
-            if workspace_pattern is not None and not re.match(
-                workspace_pattern, workspace.id, re.IGNORECASE
-            ):
+            if workspace_pattern is not None and not re.match(workspace_pattern, workspace.id):
                 continue
 
             filtered_resources = []
@@ -98,9 +95,7 @@ class Workspaces(pdt.BaseModel, extra=pdt.Extra.forbid, frozen=True):
                 if backend_type is not None and resource.type is not backend_type:
                     continue
 
-                if name_pattern is not None and not re.match(
-                    name_pattern, resource.id, re.IGNORECASE
-                ):
+                if name_pattern is not None and not re.match(name_pattern, resource.id):
                     continue
 
                 filtered_resources.append(resource)

--- a/test/test_provider.py
+++ b/test/test_provider.py
@@ -210,7 +210,7 @@ def test_remote_workspaces_filtering_prefix_collision(httpx_mock: HTTPXMock) -> 
         for backend in both_ws[workspace]
     } == {"foo", "foo-extra"}
 
-    # with extra match on name
+    # with exact match on name
     only_base = provider.backends(name="foo").by_workspace()
     assert set(only_base) == {"workspace"}
     assert {backend.resource_id.resource_id for backend in only_base["workspace"]} == {"foo"}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This patch makes the implementation of `AQTProvider.backends()` more intuitive by interpreting string filters as exact matches instead of regular expression patterns. This also matches the description in the user guide.

Resolves #84.

### Details and comments

The option to pass regular expression patterns is conserved, since it doesn't make the implementation significantly more complex. The semantics are now similar to e.g. the `url` argument `pytest-httpx`'s `add_response` hook.
