### PR TITLE
Fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
     environment: release
     permissions:
       id-token: write
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Changes to the authentication method for the PyPI publication (#87) also changed the permissions for the other steps in the release workflow. This prevents creation of the Github release ([failing job](https://github.com/qiskit-community/qiskit-aqt-provider/actions/runs/6744359261/job/18334055215)).

This patch adds the necessary permission to the full job, as documented [here](https://github.com/marketplace/actions/gh-release#permissions).
