### PR TITLE
Use qiskit_algorithms instead of deprecated qiskit.algorithms

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -106,6 +106,9 @@ ignore_missing_imports = True
 [mypy-qiskit_aer.*]
 ignore_missing_imports = True
 
+[mypy-qiskit_algorithms.*]
+ignore_missing_imports = True
+
 [mypy-qiskit_experiments.*]
 ignore_missing_imports = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Set minimal required `qiskit` version to 0.45.0 (#108)
+* Use `qiskit-algorithms` package instead of deprecated `qiskit.algorithms` in examples (#110)
 
 ## qiskit-aqt-provider v0.19.0
 

--- a/examples/grover-3-sat.py
+++ b/examples/grover-3-sat.py
@@ -19,8 +19,8 @@ import tempfile
 import textwrap
 from typing import Final, Set, Tuple
 
-from qiskit.algorithms import AmplificationProblem, Grover
 from qiskit.circuit.library.phase_oracle import PhaseOracle
+from qiskit_algorithms import AmplificationProblem, Grover
 
 from qiskit_aqt_provider import AQTProvider
 from qiskit_aqt_provider.primitives import AQTSampler

--- a/examples/number_partition.py
+++ b/examples/number_partition.py
@@ -22,7 +22,7 @@ it can be split into two non-overlapping sets that have the same sum.
 from dataclasses import dataclass
 from typing import Final, List, Set, Union
 
-from qiskit.utils import algorithm_globals
+import qiskit_algorithms
 from qiskit_algorithms.minimum_eigensolvers import QAOA
 from qiskit_algorithms.optimizers import COBYLA
 from qiskit_optimization.algorithms import MinimumEigenOptimizer, OptimizationResultStatus
@@ -81,7 +81,7 @@ if __name__ == "__main__":
     backend = AQTProvider("token").get_backend("offline_simulator_no_noise")
 
     # fix the random seeds such that the example is reproducible
-    algorithm_globals.random_seed = RANDOM_SEED
+    qiskit_algorithms.utils.algorithm_globals.random_seed = RANDOM_SEED
     backend.simulator.options.seed_simulator = RANDOM_SEED
 
     num_set = {1, 3, 4}

--- a/examples/number_partition.py
+++ b/examples/number_partition.py
@@ -22,9 +22,9 @@ it can be split into two non-overlapping sets that have the same sum.
 from dataclasses import dataclass
 from typing import Final, List, Set, Union
 
-from qiskit.algorithms.minimum_eigensolvers import QAOA
-from qiskit.algorithms.optimizers import COBYLA
 from qiskit.utils import algorithm_globals
+from qiskit_algorithms.minimum_eigensolvers import QAOA
+from qiskit_algorithms.optimizers import COBYLA
 from qiskit_optimization.algorithms import MinimumEigenOptimizer, OptimizationResultStatus
 from qiskit_optimization.applications import NumberPartition
 

--- a/examples/qaoa.py
+++ b/examples/qaoa.py
@@ -17,10 +17,10 @@ This is the same example as in vqe.py, but uses QAOA instead of VQE as solver.
 
 from typing import Final
 
-from qiskit.algorithms.minimum_eigensolvers import QAOA
-from qiskit.algorithms.optimizers import COBYLA
 from qiskit.quantum_info import SparsePauliOp
 from qiskit.utils import algorithm_globals
+from qiskit_algorithms.minimum_eigensolvers import QAOA
+from qiskit_algorithms.optimizers import COBYLA
 
 from qiskit_aqt_provider import AQTProvider
 from qiskit_aqt_provider.primitives import AQTSampler

--- a/examples/qaoa.py
+++ b/examples/qaoa.py
@@ -17,8 +17,8 @@ This is the same example as in vqe.py, but uses QAOA instead of VQE as solver.
 
 from typing import Final
 
+import qiskit_algorithms
 from qiskit.quantum_info import SparsePauliOp
-from qiskit.utils import algorithm_globals
 from qiskit_algorithms.minimum_eigensolvers import QAOA
 from qiskit_algorithms.optimizers import COBYLA
 
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     sampler = AQTSampler(backend)
 
     # fix the random seeds such that the example is reproducible
-    algorithm_globals.random_seed = RANDOM_SEED
+    qiskit_algorithms.utils.algorithm_globals.random_seed = RANDOM_SEED
     backend.simulator.options.seed_simulator = RANDOM_SEED
 
     # Hamiltonian: Ising model on two spin 1/2 without external field

--- a/examples/vqe.py
+++ b/examples/vqe.py
@@ -14,9 +14,9 @@
 
 from typing import Final
 
+import qiskit_algorithms
 from qiskit.circuit.library import TwoLocal
 from qiskit.quantum_info import SparsePauliOp
-from qiskit.utils import algorithm_globals
 from qiskit_algorithms.minimum_eigensolvers import VQE
 from qiskit_algorithms.optimizers import COBYLA
 
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     estimator = AQTEstimator(backend)
 
     # fix the random seeds such that the example is reproducible
-    algorithm_globals.random_seed = RANDOM_SEED
+    qiskit_algorithms.utils.algorithm_globals.random_seed = RANDOM_SEED
     backend.simulator.options.seed_simulator = RANDOM_SEED
 
     # Hamiltonian: Ising model on two spin 1/2 without external field

--- a/examples/vqe.py
+++ b/examples/vqe.py
@@ -14,11 +14,11 @@
 
 from typing import Final
 
-from qiskit.algorithms.minimum_eigensolvers import VQE
-from qiskit.algorithms.optimizers import COBYLA
 from qiskit.circuit.library import TwoLocal
 from qiskit.quantum_info import SparsePauliOp
 from qiskit.utils import algorithm_globals
+from qiskit_algorithms.minimum_eigensolvers import VQE
+from qiskit_algorithms.optimizers import COBYLA
 
 from qiskit_aqt_provider import AQTProvider
 from qiskit_aqt_provider.aqt_resource import OfflineSimulatorResource

--- a/poetry.lock
+++ b/poetry.lock
@@ -692,9 +692,9 @@ openapi-spec-validator = ">=0.2.8,<=0.5.7"
 packaging = "*"
 prance = ">=0.18.2"
 pydantic = [
+    {version = ">=1.10.0,<3.0", extras = ["email"], markers = "python_version >= \"3.11\" and python_version < \"4.0\""},
     {version = ">=1.5.1,<3.0", extras = ["email"], markers = "python_version < \"3.10\""},
     {version = ">=1.9.0,<3.0", extras = ["email"], markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
-    {version = ">=1.10.0,<3.0", extras = ["email"], markers = "python_version >= \"3.11\" and python_version < \"4.0\""},
 ]
 PySnooper = ">=0.4.1,<2.0.0"
 toml = ">=0.10.0,<1.0.0"
@@ -2217,9 +2217,9 @@ files = [
 
 [package.dependencies]
 numpy = [
+    {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
     {version = ">=1.20.3", markers = "python_version < \"3.10\""},
     {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
-    {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -3161,6 +3161,22 @@ scipy = ">=1.0"
 
 [package.extras]
 dask = ["dask", "distributed"]
+
+[[package]]
+name = "qiskit-algorithms"
+version = "0.2.1"
+description = "Qiskit Algorithms: A library of quantum computing algorithms"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "qiskit-algorithms-0.2.1.tar.gz", hash = "sha256:fa27babdcabb8613f261743d83d915dd624b1d94737b450d9d0427ed36bd187e"},
+    {file = "qiskit_algorithms-0.2.1-py3-none-any.whl", hash = "sha256:4d83b63921c47fe3d9ee2962c0afcfc6009d42f94f23a2e907e5338f98e3e3f7"},
+]
+
+[package.dependencies]
+numpy = ">=1.17"
+qiskit-terra = ">=0.24"
+scipy = ">=1.4"
 
 [[package]]
 name = "qiskit-experiments"
@@ -4607,10 +4623,10 @@ docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.link
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
 [extras]
-examples = ["qiskit-optimization"]
+examples = ["qiskit-algorithms", "qiskit-optimization"]
 examples-problematic = ["tweedledum"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "25d6d01a3cbec638579ecdb2f2577885757154034ba0fb1de2d13a53ecc2313f"
+content-hash = "c50647ad7500b9fc9bd6a04321850187130c93863147563db827e9567332b2ab"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3247,21 +3247,22 @@ visualization = ["ipython (>=5.0.0)", "ipyvue (>=1.4.1)", "ipyvuetify (>=1.1)", 
 
 [[package]]
 name = "qiskit-optimization"
-version = "0.5.0"
-description = "Qiskit Optimization: A library of quantum computing optimizations"
+version = "0.6.0"
+description = "Qiskit Optimization: A library for optimization applications using quantum computing"
 optional = true
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "qiskit-optimization-0.5.0.tar.gz", hash = "sha256:4804831e590a7159c2bd2be71750cde0c95a3b06e14a4843346e2ebcc7231e01"},
-    {file = "qiskit_optimization-0.5.0-py3-none-any.whl", hash = "sha256:eb9d8788d197d2812dcf6bea69a8af49c4c044b947f4b15a169fdf4c4fe5ab7a"},
+    {file = "qiskit-optimization-0.6.0.tar.gz", hash = "sha256:a37816ec5dbd7d3048b2f6c6d77c3e0eb8af0aa3ede3ff0f1b7dd0e7648ab4f0"},
+    {file = "qiskit_optimization-0.6.0-py3-none-any.whl", hash = "sha256:9e560cac6f9e63089fe4ec98253a47553aa698f32cc67a3c64dc8ca841f302d1"},
 ]
 
 [package.dependencies]
 docplex = ">=2.21.207,<2.24.231 || >2.24.231"
 networkx = ">=2.6.3"
 numpy = ">=1.17"
-qiskit-terra = ">=0.22.4"
-scipy = ">=1.4"
+qiskit = ">=0.44"
+qiskit-algorithms = ">=0.2.0"
+scipy = ">=1.9.0"
 setuptools = ">=40.1.0"
 
 [package.extras]
@@ -4629,4 +4630,4 @@ examples-problematic = ["tweedledum"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "c50647ad7500b9fc9bd6a04321850187130c93863147563db827e9567332b2ab"
+content-hash = "f562fe1c258f7a8b5206a9bcf7aee00074595d3873573ad31043330f60294aba"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ python-dotenv = ">=1"
 qiskit = ">=0.45.0"
 qiskit-aer = ">=0.11"
 qiskit-algorithms = { version = ">=0.2.1", optional = true }
-qiskit-optimization = { version = ">=0.5.0", optional = true }
+qiskit-optimization = { version = ">=0.6.0", optional = true }
 tabulate = ">=0.9.0"
 tqdm = ">=4"
 tweedledum = { version = ">=1", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ pydantic = ">=1.10.8,<2"
 python-dotenv = ">=1"
 qiskit = ">=0.45.0"
 qiskit-aer = ">=0.11"
+qiskit-algorithms = { version = ">=0.2.1", optional = true }
 qiskit-optimization = { version = ">=0.5.0", optional = true }
 tabulate = ">=0.9.0"
 tqdm = ">=4"
@@ -94,7 +95,8 @@ examples-problematic = [
     "tweedledum"
 ]
 examples = [
-    "qiskit-optimization"
+    "qiskit-algorithms",
+    "qiskit-optimization",
 ]
 
 [build-system]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Switch to using the split package [`qiskit-algorithms`](https://pypi.org/project/qiskit-algorithms/).

This is blocked by the upcoming release 0.6 of [`qiskit-optimization`](https://pypi.org/project/qiskit-optimization/) that contains qiskit-community/qiskit-optimization#537.
