### PR TITLE
Use production instead of staging portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Set minimal required `qiskit` version to 0.45.0 (#108)
 * Use `qiskit-algorithms` package instead of deprecated `qiskit.algorithms` in examples (#110)
-* Use arnica.aqt.eu instead of arnica-stage.aqt.eu (#111)
+* Use arnica.aqt.eu instead of arnica-stage.aqt.eu as default portal (#111)
 
 ## qiskit-aqt-provider v0.19.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Set minimal required `qiskit` version to 0.45.0 (#108)
 * Use `qiskit-algorithms` package instead of deprecated `qiskit.algorithms` in examples (#110)
+* Use arnica.aqt.eu instead of arnica-stage.aqt.eu (#111)
 
 ## qiskit-aqt-provider v0.19.0
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -241,7 +241,7 @@ to the transpiled one:
 Transpiler bypass
 -----------------
 
-.. warning:: We highly recommend to always use the built-in transpiler, at least with ``optimization_level=0``. This guarantees that the quantum circuit is valid for submission to the AQT cloud. In particular, it wraps the gate parameters to fit in the restricted ranges accepted by the `AQT API <https://arnica-stage.aqt.eu/api/v1/docs>`_. In addition, higher optimization levels may significantly improve the circuit execution speed.
+.. warning:: We highly recommend to always use the built-in transpiler, at least with ``optimization_level=0``. This guarantees that the quantum circuit is valid for submission to the AQT cloud. In particular, it wraps the gate parameters to fit in the restricted ranges accepted by the `AQT API <https://arnica.aqt.eu/api/v1/docs>`_. In addition, higher optimization levels may significantly improve the circuit execution speed.
 
 If a circuit is already defined in terms of the :ref:`native gates set <basis-gates>` with their restricted parameter ranges and no optimization is wanted, it can be submitted for execution without any additional transformation using the :meth:`AQTResource.run <qiskit_aqt_provider.aqt_resource.AQTResource.run>` method:
 
@@ -268,7 +268,7 @@ Circuits that do not satisfy the AQT API restrictions are rejected by raising a 
 Transpiler plugin
 -----------------
 
-The built-in transpiler largely leverages the :mod:`qiskit.transpiler`. Custom passes are registered in addition to the presets, irrespective of the optimization level, to ensure that the transpiled circuit is compatible with the restricted parameter ranges accepted by the `AQT API <https://arnica-stage.aqt.eu/api/v1/docs>`_:
+The built-in transpiler largely leverages the :mod:`qiskit.transpiler`. Custom passes are registered in addition to the presets, irrespective of the optimization level, to ensure that the transpiled circuit is compatible with the restricted parameter ranges accepted by the `AQT API <https://arnica.aqt.eu/api/v1/docs>`_:
 
 * in the translation stage, the :class:`WrapRxxAngles <qiskit_aqt_provider.transpiler_plugin.WrapRxxAngles>` pass exploits the periodicity of the :class:`RXXGate <qiskit.circuit.library.RXXGate>` to wrap its angle :math:`\theta` to the :math:`[0,\,\pi/2]` range. This may come at the expense of extra single-qubit rotations.
 * in the scheduling stage, the :class:`RewriteRxAsR <qiskit_aqt_provider.transpiler_plugin.RewriteRxAsR>` pass rewrites :class:`RXGate <qiskit.circuit.library.RXGate>` operations as :class:`RGate <qiskit.circuit.library.RGate>` and wraps the angles :math:`\theta\in[0,\,\pi]` and :math:`\phi\in[0,\,2\pi]`. This does not restrict the generality of quantum circuits and enables efficient native implementations.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -75,4 +75,4 @@ For more details see the :ref:`user guide <user-guide>`, a selection of `example
 
   Repository <https://github.com/qiskit-community/qiskit-aqt-provider>
   AQT <https://www.aqt.eu/qc-systems>
-  API reference <https://arnica-stage.aqt.eu/api/v1/docs>
+  API reference <https://arnica.aqt.eu/api/v1/docs>

--- a/qiskit_aqt_provider/aqt_provider.py
+++ b/qiskit_aqt_provider/aqt_provider.py
@@ -143,7 +143,7 @@ class AQTProvider(ProviderV1):
     """Provider for backends from Alpine Quantum Technologies (AQT)."""
 
     # Set AQT_PORTAL_URL environment variable to override
-    DEFAULT_PORTAL_URL: Final = "https://arnica-stage.aqt.eu"
+    DEFAULT_PORTAL_URL: Final = "https://arnica.aqt.eu"
 
     def __init__(
         self,


### PR DESCRIPTION
### Summary

So far the staging back-end of Arnica was used. This pull request changes to the production back-end.

### Details and comments

Old back-end: https://arnica-stage.aqt.eu
New back-end: https://arnica.aqt.eu