### PR TITLE
workflows/poetry: aggregate coverage over all Python versions

### DIFF
--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -63,3 +63,13 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           file: coverage.lcov
+          parallel: true
+          flag-name: run ${{ join(matrix.*, ' - ') }}
+  finish:
+    needs: tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close parallel coverage build
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The parallel CI jobs across different Python versions cause issues with the coverage report submission (see e.g. [this job](https://github.com/qiskit-community/qiskit-aqt-provider/actions/runs/7046836909/job/19179603547)).

This patch configures the workflow as a [parallel build](https://docs.coveralls.io/parallel-builds) to the Coveralls app. This aggregates the coverage from all jobs to the final coverage value reported e.g. to the badge. This is relevant, since some examples cannot be run on all Python versions (due to the lack of wheels for recent Python versions).
