### PR TITLE
docs: improve typesetting of braket symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add support for Python 3.12 (#79)
 * Remove support for Python 3.8 (#79)
+* Improve math typesetting in user guide (#124)
 
 ## qiskit-aqt-provider v1.1.0
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -299,7 +299,7 @@ Reset operations are not supported
 
 Because AQT backends do not support in-circuit state reinitialization of specific qubits, the :class:`Reset <qiskit.circuit.library.Reset>` operation is not supported. The Qiskit transpiler will fail synthesis for circuits using it (e.g. through :meth:`QuantumCircuit.initialize <qiskit.circuit.QuantumCircuit.initialize>`) when targeting AQT backends.
 
-AQT backends always prepare the quantum register in the :math:`|0>\otimes...\otimes|0>` state. Thus, :meth:`QuantumCircuit.prepare_state <qiskit.circuit.QuantumCircuit.prepare_state>` is an alternative to :meth:`QuantumCircuit.initialize <qiskit.circuit.QuantumCircuit.initialize>` as first instruction in the circuit:
+AQT backends always prepare the quantum register in the :math:`|0\rangle\otimes...\otimes|0\rangle` state. Thus, :meth:`QuantumCircuit.prepare_state <qiskit.circuit.QuantumCircuit.prepare_state>` is an alternative to :meth:`QuantumCircuit.initialize <qiskit.circuit.QuantumCircuit.initialize>` as first instruction in the circuit:
 
 .. jupyter-execute::
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -299,7 +299,7 @@ Reset operations are not supported
 
 Because AQT backends do not support in-circuit state reinitialization of specific qubits, the :class:`Reset <qiskit.circuit.library.Reset>` operation is not supported. The Qiskit transpiler will fail synthesis for circuits using it (e.g. through :meth:`QuantumCircuit.initialize <qiskit.circuit.QuantumCircuit.initialize>`) when targeting AQT backends.
 
-AQT backends always prepare the quantum register in the :math:`|0\rangle\otimes...\otimes|0\rangle` state. Thus, :meth:`QuantumCircuit.prepare_state <qiskit.circuit.QuantumCircuit.prepare_state>` is an alternative to :meth:`QuantumCircuit.initialize <qiskit.circuit.QuantumCircuit.initialize>` as first instruction in the circuit:
+AQT backends always prepare the quantum register in the :math:`|0\rangle\otimes\cdots\otimes|0\rangle` state. Thus, :meth:`QuantumCircuit.prepare_state <qiskit.circuit.QuantumCircuit.prepare_state>` is an alternative to :meth:`QuantumCircuit.initialize <qiskit.circuit.QuantumCircuit.initialize>` as first instruction in the circuit:
 
 .. jupyter-execute::
 


### PR DESCRIPTION
### Summary

The user guide uses ">" to denote braket notation, which looks weird:

![image](https://github.com/qiskit-community/qiskit-aqt-provider/assets/84843123/2549b923-6ae1-44fc-b143-8352169f5d18)


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->



### Details and comments

Use  "\rangle" to denote right braket:

![image](https://github.com/qiskit-community/qiskit-aqt-provider/assets/84843123/e67ae8fe-3e8c-4ff8-ab2b-6b60ca782e31)
