### PR TITLE
Remove most links to qiskit.org

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at qiskit@qiskit.org. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at qiskit@us.ibm.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v1.json)](https://github.com/charliermarsh/ruff)
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
 
-[Qiskit](https://qiskit.org/) is an open-source SDK for working with quantum computers at the level of circuits, algorithms, and application modules.
+[Qiskit](https://www.ibm.com/quantum/qiskit) is an open-source SDK for working with quantum computers at the level of circuits, algorithms, and application modules.
 
 This project contains a provider that allows access to [AQT](https://www.aqt.eu/) ion-trap quantum computing
 systems.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,5 +80,5 @@ autodoc_pydantic_field_list_validators = False
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "qiskit": ("https://qiskit.org/documentation/", None),
+    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/", None),
 }

--- a/examples/grover-3-sat.py
+++ b/examples/grover-3-sat.py
@@ -13,7 +13,7 @@
 """3-SAT solving example using the Grover algorithm.
 
 This is a modified version of the corresponding
-[Qiskit tutorial](https://qiskit.org/documentation/tutorials/algorithms/07_grover_examples.html).
+[Qiskit tutorial](https://qiskit-community.github.io/qiskit-algorithms/tutorials/07_grover_examples.html).
 """
 import tempfile
 import textwrap

--- a/qiskit_aqt_provider/aqt_resource.py
+++ b/qiskit_aqt_provider/aqt_resource.py
@@ -166,7 +166,7 @@ class AQTResource(Backend):
             "future release. Instead you should access these attributes directly "
             "off the object or via the .target attribute. You can refer to qiskit "
             "backend interface transition guide for the exact changes: "
-            "https://qiskit.org/documentation/apidoc/providers.html#backendv1-backendv2",
+            "https://docs.quantum.ibm.com/api/qiskit/providers#migrating-between-backend-api-versions",
             DeprecationWarning,
         )
         return self._configuration
@@ -177,7 +177,7 @@ class AQTResource(Backend):
             "future release. Instead you should access these attributes directly "
             "off the object or via the .target attribute. You can refer to qiskit "
             "backend interface transition guide for the exact changes: "
-            "https://qiskit.org/documentation/apidoc/providers.html#backendv1-backendv2",
+            "https://docs.quantum.ibm.com/api/qiskit/providers#migrating-between-backend-api-versions",
             DeprecationWarning,
         )
 
@@ -295,7 +295,7 @@ class OfflineSimulatorResource(AQTResource):
     `with_noise_model` is true, a noise model approximating that of AQT hardware backends is used.
 
     .. tip::
-      The simulator backend is provided by `Qiskit Aer <https://qiskit.org/ecosystem/aer/>`_. The
+      The simulator backend is provided by `Qiskit Aer <https://qiskit.github.io/qiskit-aer//>`_. The
       Qiskit Aer resource is exposed for detailed detuning as the
       ``OfflineSimulatorResource.simulator`` attribute.
     """


### PR DESCRIPTION
The only one we can't yet remove is to the CLA PDFs, per https://github.com/Qiskit/documentation/issues/796.