### PR TITLE
Remove references to deprecated qiskit.execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Remove references to the deprecated function `qiskit.execute` (#136)
+
 ## qiskit-aqt-provider v1.2.0
 
 * Add support for Python 3.12 (#79)

--- a/examples/example.py
+++ b/examples/example.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
     # match. For example:
     backend = provider.get_backend("offline_simulator_no_noise", workspace="default")
 
-    # Create a 4-qubit GHZ state
+    # Define a quantum circuit that produces a 2-qubit GHZ state.
     qc = QuantumCircuit(4)
     qc.h(0)
     qc.cx(0, 1)
@@ -42,7 +42,11 @@ if __name__ == "__main__":
     qc.cx(0, 3)
     qc.measure_all()
 
-    result = qiskit.execute(qc, backend, shots=200).result()
+    # Transpile for the target backend.
+    qc = qiskit.transpile(qc, backend)
+
+    # Execute on the target backend.
+    result = backend.run(qc, shots=200).result()
 
     if result.success:
         print(result.get_counts())

--- a/examples/example_noise.py
+++ b/examples/example_noise.py
@@ -37,13 +37,17 @@ if __name__ == "__main__":
     # match. For example:
     backend = provider.get_backend("offline_simulator_noise", workspace="default")
 
-    # Create a 2-qubit GHZ state
+    # Define a quantum circuit that produces a 2-qubit GHZ state.
     qc = QuantumCircuit(2)
     qc.h(0)
     qc.cx(0, 1)
     qc.measure_all()
 
-    result = qiskit.execute(qc, backend, shots=200).result()
+    # Transpile for the target backend.
+    qc = qiskit.transpile(qc, backend)
+
+    # Execute on the target backend.
+    result = backend.run(qc, shots=200).result()
 
     if result.success:
         # due to the noise, also the states '01' and '10' may be populated!

--- a/qiskit_aqt_provider/aqt_job.py
+++ b/qiskit_aqt_provider/aqt_job.py
@@ -120,23 +120,23 @@ class AQTJob(JobV1):
     Jobs contain one or more quantum circuits that are executed with a common
     set of options (see :class:`AQTOptions <qiskit_aqt_provider.aqt_options.AQTOptions>`).
 
-    Job handles should be retrieved from calls to
-    :func:`qiskit.execute <qiskit.execute_function.execute>`
-    or :meth:`AQTResource.run <qiskit_aqt_provider.aqt_resource.AQTResource.run>`, both of which
-    immediately submit the job for execution. The :meth:`result` method allows blocking until a job
+    Job handles should be retrieved from calls
+    to :meth:`AQTResource.run <qiskit_aqt_provider.aqt_resource.AQTResource.run>`, which immediately
+    returns after submitting the job. The :meth:`result` method allows blocking until a job
     completes:
 
     >>> import qiskit
     >>> from qiskit.providers import JobStatus
     >>> from qiskit_aqt_provider import AQTProvider
-    ...
+    >>>
     >>> backend = AQTProvider("").get_backend("offline_simulator_no_noise")
-    ...
+    >>>
     >>> qc = qiskit.QuantumCircuit(1)
     >>> _ = qc.rx(3.14, 0)
     >>> _ = qc.measure_all()
-    ...
-    >>> job = qiskit.execute(qc, backend, shots=100)
+    >>> qc = qiskit.transpile(qc, backend)
+    >>>
+    >>> job = backend.run(qc, shots=100)
     >>> result = job.result()
     >>> job.status() is JobStatus.DONE
     True

--- a/qiskit_aqt_provider/aqt_options.py
+++ b/qiskit_aqt_provider/aqt_options.py
@@ -28,25 +28,25 @@ class AQTOptions(pdt.BaseModel, Mapping[str, Any]):
 
     >>> import qiskit
     >>> from qiskit_aqt_provider import AQTProvider
-    ...
+    >>>
     >>> backend = AQTProvider("").get_backend("offline_simulator_no_noise")
-    ...
+    >>>
     >>> qc = qiskit.QuantumCircuit(1)
     >>> _ = qc.rx(3.14, 0)
     >>> _ = qc.measure_all()
-    ...
+    >>> qc = qiskit.transpile(qc, backend)
+    >>>
     >>> backend.options.shots = 50
-    >>> result = qiskit.execute(qc, backend).result()
+    >>> result = backend.run(qc).result()
     >>> sum(result.get_counts().values())
     50
 
     Option overrides can also be applied on a per-job basis, as keyword arguments to
-    :func:`qiskit.execute <qiskit.execute_function.execute>` or
     :meth:`AQTResource.run <qiskit_aqt_provider.aqt_resource.AQTResource.run>`:
 
     >>> backend.options.shots
     50
-    >>> result = qiskit.execute(qc, backend, shots=100).result()
+    >>> result = backend.run(qc, shots=100).result()
     >>> sum(result.get_counts().values())
     100
     """

--- a/qiskit_aqt_provider/test/utils.py
+++ b/qiskit_aqt_provider/test/utils.py
@@ -1,0 +1,70 @@
+# This code is part of Qiskit.
+#
+# (C) Alpine Quantum Technologies GmbH 2024
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Miscellaneous testing utilities."""
+
+from typing import TypeVar, Union
+
+import annotated_types
+from pydantic import BaseModel
+
+T = TypeVar("T", bound=annotated_types.BaseMetadata)
+
+
+def get_field_constraint(
+    model: Union[BaseModel, type[BaseModel]],
+    field: str,
+    constraint: type[T],
+) -> T:
+    """Retrieve a given piece of metadata from a Pydantic model field.
+
+    Args:
+        model: model owning the field.
+        field: name of the field to inspect.
+        constraint: type of the annotation to retrieve.
+
+    Returns:
+        instance of the first matching annotation.
+
+    Raises:
+        AttributeError: the passed model doesn't contain a field with the given name.
+        ValueError: the target field doesn't contain a matching annotation.
+
+    Examples:
+       >>> from pydantic import BaseModel
+       >>> from typing import Annotated
+       >>> from annotated_types import Ge, Le
+       >>>
+       >>> class M(BaseModel):
+       ...     x: Annotated[int, Ge(3)]
+       ...
+       >>> get_field_constraint(M, "x", Ge)
+       Ge(ge=3)
+       >>> get_field_constraint(M(x=4), "x", Ge)
+       Ge(ge=3)
+       >>> get_field_constraint(M, "x", Le)
+       Traceback (most recent call last):
+       ...
+       ValueError: <class 'annotated_types.Le'>
+       >>> get_field_constraint(M, "y", Ge)
+       Traceback (most recent call last):
+       ...
+       AttributeError: y
+    """
+    if (field_info := model.model_fields.get(field)) is None:
+        raise AttributeError(field)
+
+    for metadata in field_info.metadata:
+        if isinstance(metadata, constraint):
+            return metadata
+
+    raise ValueError(constraint)

--- a/test/test_execution.py
+++ b/test/test_execution.py
@@ -19,24 +19,20 @@ expected.
 import re
 import typing
 from collections import Counter
-from fractions import Fraction
 from math import pi
 from typing import Union
 
-import numpy as np
 import pytest
 import qiskit
 from qiskit import ClassicalRegister, QiskitError, QuantumCircuit, QuantumRegister, quantum_info
 from qiskit.providers import Backend
 from qiskit.providers.jobstatus import JobStatus
-from qiskit.result import Counts
 from qiskit.transpiler import TranspilerError
 from qiskit_aer import AerProvider, AerSimulator
-from qiskit_experiments.library import QuantumVolume
 
 from qiskit_aqt_provider import AQTProvider
 from qiskit_aqt_provider.aqt_resource import AQTResource
-from qiskit_aqt_provider.test.circuits import assert_circuits_equivalent, qft_circuit
+from qiskit_aqt_provider.test.circuits import assert_circuits_equivalent
 from qiskit_aqt_provider.test.fixtures import MockSimulator
 from qiskit_aqt_provider.test.resources import TestResource
 from qiskit_aqt_provider.test.timeout import timeout
@@ -48,7 +44,7 @@ def test_empty_circuit(shots: int, offline_simulator_no_noise: AQTResource) -> N
     qc = QuantumCircuit(1)
     qc.measure_all()
 
-    job = qiskit.execute(qc, offline_simulator_no_noise, shots=shots)
+    job = offline_simulator_no_noise.run(qc, shots=shots)
     assert job.result().get_counts() == {"0": shots}
 
 
@@ -62,7 +58,7 @@ def test_circuit_success_lifecycle() -> None:
     qc = QuantumCircuit(1)
     qc.measure_all()
 
-    job = qiskit.execute(qc, backend)
+    job = backend.run(qc)
 
     assert job.status() is JobStatus.QUEUED
 
@@ -89,7 +85,7 @@ def test_error_circuit() -> None:
     qc = QuantumCircuit(1)
     qc.measure_all()
 
-    result = qiskit.execute(qc, backend).result()
+    result = backend.run(qc).result()
     assert result.success is False
     assert backend.error_message == result._metadata["error"]
 
@@ -101,7 +97,7 @@ def test_cancelled_circuit() -> None:
     qc = QuantumCircuit(1)
     qc.measure_all()
 
-    result = qiskit.execute(qc, backend).result()
+    result = backend.run(qc).result()
     assert result.success is False
 
 
@@ -116,22 +112,6 @@ def test_simple_backend_run(shots: int, offline_simulator_no_noise: AQTResource)
     job = offline_simulator_no_noise.run(trans_qc, shots=shots)
 
     assert job.result().get_counts() == {"1": shots}
-
-
-@pytest.mark.parametrize("shots", [1, 100])
-def test_simple_backend_execute(shots: int, offline_simulator_no_noise: AQTResource) -> None:
-    """Run two simple circuits with `qiskit.execute()`."""
-    qc0 = QuantumCircuit(2)
-    qc0.rx(pi, 0)
-    qc0.measure_all()
-
-    qc1 = QuantumCircuit(2)
-    qc1.rx(pi, 1)
-    qc1.measure_all()
-
-    # qiskit.execute calls the transpiler automatically
-    job = qiskit.execute([qc0, qc1], backend=offline_simulator_no_noise, shots=shots)
-    assert job.result().get_counts() == [{"01": shots}, {"10": shots}]
 
 
 @pytest.mark.parametrize("backend", [MockSimulator(noisy=False), MockSimulator(noisy=True)])
@@ -151,7 +131,7 @@ def test_simple_backend_execute_noisy(backend: MockSimulator) -> None:
 
     counts: typing.Counter[str] = Counter()
     for _ in range(total_shots // shots):
-        job = qiskit.execute(qc, backend=backend, shots=shots)
+        job = backend.run(qiskit.transpile(qc, backend=backend), shots=shots)
         counts += Counter(job.result().get_counts())
 
     assert sum(counts.values()) == total_shots
@@ -217,7 +197,9 @@ def test_get_memory_simple(
     qc.cx(0, 1)
     qc.measure_all()
 
-    result = qiskit.execute(qc, offline_simulator_no_noise, shots=shots, memory=memory_opt).result()
+    result = offline_simulator_no_noise.run(
+        qiskit.transpile(qc, offline_simulator_no_noise), shots=shots, memory=memory_opt
+    ).result()
 
     if memory_opt:
         memory = result.get_memory()
@@ -244,7 +226,9 @@ def test_get_memory_ancilla_qubits(shots: int, offline_simulator_no_noise: AQTRe
     qc.rxx(pi / 2, qr_aux[0], qr_aux[1])
     qc.measure(qr, memory)
 
-    job = qiskit.execute(qc, offline_simulator_no_noise, shots=shots, memory=True)
+    job = offline_simulator_no_noise.run(
+        qiskit.transpile(qc, offline_simulator_no_noise), shots=shots, memory=True
+    )
     memory = job.result().get_memory()
 
     assert set(memory) == {"11"}
@@ -264,11 +248,13 @@ def test_get_memory_bit_ordering(shots: int, offline_simulator_no_noise: AQTReso
     qc.measure_all()
 
     aqt_memory = (
-        qiskit.execute(qc, offline_simulator_no_noise, shots=shots, memory=True)
+        offline_simulator_no_noise.run(
+            qiskit.transpile(qc, offline_simulator_no_noise), shots=shots, memory=True
+        )
         .result()
         .get_memory()
     )
-    sim_memory = qiskit.execute(qc, sim, shots=shots, memory=True).result().get_memory()
+    sim_memory = sim.run(qiskit.transpile(qc, sim), shots=shots, memory=True).result().get_memory()
 
     assert set(sim_memory) == set(aqt_memory)
 
@@ -301,13 +287,17 @@ def test_regression_issue_85(backend: Backend) -> None:
     perm_qubits = empty_3.compose(base, qubits=[0, 2, 1])
     perm_all = empty_3.compose(base, qubits=[0, 2, 1], clbits=[0, 2, 1])
 
-    base_bitstrings = set(qiskit.execute(base, backend).result().get_counts())
+    base_bitstrings = set(backend.run(qiskit.transpile(base, backend)).result().get_counts())
     assert base_bitstrings == {"000", "101"}
 
-    perm_qubits_bitstrings = set(qiskit.execute(perm_qubits, backend).result().get_counts())
+    perm_qubits_bitstrings = set(
+        backend.run(qiskit.transpile(perm_qubits, backend)).result().get_counts()
+    )
     assert perm_qubits_bitstrings == {"000", "101"}
 
-    perm_all_bitstrings = set(qiskit.execute(perm_all, backend).result().get_counts())
+    perm_all_bitstrings = set(
+        backend.run(qiskit.transpile(perm_all, backend)).result().get_counts()
+    )
     assert perm_all_bitstrings == {"000", "011"}
 
 
@@ -320,7 +310,9 @@ def test_bell_states(shots: int, qubits: int, offline_simulator_no_noise: AQTRes
         qc.cx(0, qubit)
     qc.measure_all()
 
-    job = qiskit.execute(qc, offline_simulator_no_noise, shots=shots)
+    job = offline_simulator_no_noise.run(
+        qiskit.transpile(qc, offline_simulator_no_noise), shots=shots
+    )
     counts = job.result().get_counts()
 
     assert set(counts.keys()) == {"0" * qubits, "1" * qubits}
@@ -352,8 +344,9 @@ def test_state_preparation(
     qc.measure_all()
 
     shots = 100
-    job = qiskit.execute(
-        qc, offline_simulator_no_noise, shots=shots, optimization_level=optimization_level
+    job = offline_simulator_no_noise.run(
+        qiskit.transpile(qc, offline_simulator_no_noise, optimization_level=optimization_level),
+        shots=shots,
     )
     counts = job.result().get_counts()
 
@@ -371,8 +364,9 @@ def test_state_preparation_single_qubit(
     qc.measure_all()
 
     shots = 100
-    job = qiskit.execute(
-        qc, offline_simulator_no_noise, shots=shots, optimization_level=optimization_level
+    job = offline_simulator_no_noise.run(
+        qiskit.transpile(qc, offline_simulator_no_noise, optimization_level=optimization_level),
+        shots=shots,
     )
     counts = job.result().get_counts()
 
@@ -413,115 +407,10 @@ def test_cswap(optimization_level: int, offline_simulator_no_noise: AQTResource)
 
     qc.measure_all()
     shots = 200
-    job = qiskit.execute(
-        qc, offline_simulator_no_noise, optimization_level=optimization_level, shots=shots
+    job = offline_simulator_no_noise.run(
+        qiskit.transpile(qc, offline_simulator_no_noise, optimization_level=optimization_level),
+        shots=shots,
     )
     counts = job.result().get_counts()
 
     assert counts == {"011": shots}
-
-
-@pytest.mark.parametrize(("shots", "qubits"), [(100, 3)])
-def test_simulator_quantum_volume(
-    shots: int, qubits: int, offline_simulator_no_noise: AQTResource
-) -> None:
-    """Run a qiskit_experiments.library.QuantumVolume job. Check that the noiseless simulator
-    has at least quantum volume 2**qubits.
-    """
-    experiment = QuantumVolume(list(range(qubits)), offline_simulator_no_noise, trials=100)
-    experiment.set_transpile_options(optimization_level=0)
-    experiment.set_run_options(shots=shots)
-    job = experiment.run()
-
-    result = job.analysis_results("quantum_volume")
-    assert result.value == (1 << qubits)
-    assert result.extra["success"]
-
-
-def test_period_finding_circuit(offline_simulator_no_noise: AQTResource) -> None:
-    """Run a period-finding circuit for the function 13**x mod 15 on the offline simulator.
-
-    Do 20 evaluations of the 2-shot procedure and collect results. Check that the correct
-    period (4) is found often enough.
-    """
-
-    # The function to find the period of
-    def f(x: int) -> int:
-        return pow(13, x, 15)
-
-    def f_circuit(num_qubits: int) -> QuantumCircuit:
-        """Quantum circuit for f(x) = 13^x mod 15."""
-        qr_x = QuantumRegister(num_qubits, "x")
-        qr_fx = QuantumRegister(4, "f(x)")  # 4 bits are enough to store any modulo 15 value
-
-        qc = QuantumCircuit(qr_x, qr_fx)
-
-        qc.x(qr_fx[0])
-        qc.x(qr_fx[2])
-        qc.x(qr_x[0])
-        qc.ccx(qr_x[0], qr_x[1], qr_fx[0])
-        qc.x(qr_x[0])
-        qc.ccx(qr_x[0], qr_x[1], qr_fx[1])
-        qc.x(qr_x[0])
-        qc.x(qr_x[1])
-        qc.ccx(qr_x[0], qr_x[1], qr_fx[2])
-        qc.x(qr_x[0])
-        qc.ccx(qr_x[0], qr_x[1], qr_fx[3])
-        qc.x(qr_x[1])
-
-        return qc
-
-    # Period finding circuit
-    num_qubits = 8
-    qr_x = QuantumRegister(num_qubits, "x")
-    qr_fx = QuantumRegister(4, "f(x)")
-    cr_x = ClassicalRegister(num_qubits, "c_x")
-    qc = QuantumCircuit(qr_x, qr_fx, cr_x)
-
-    # Hadamard gates for x register
-    for qubit in range(num_qubits):
-        qc.h(qr_x[qubit])
-
-    # Create f(x) and QFT subcircuits, and add them to qc
-    qc_f = f_circuit(num_qubits)
-    qc_qft = qft_circuit(num_qubits)
-    gate_f = qc_f.to_gate(label="f(x)")
-    gate_qft = qc_qft.to_gate(label="QFT")
-    qc.append(gate_f, range(num_qubits + 4))
-    qc.append(gate_qft, range(num_qubits))
-
-    # Measure qubits in x register
-    qc.measure(qr_x, cr_x)
-
-    def iteration() -> Counts:
-        result = qiskit.execute(qc, offline_simulator_no_noise, shots=2).result()
-        return result.get_counts()
-
-    n_attempts = 20
-    results: list[bool] = []
-
-    # run the circuits (2 shots) n_attempts times
-    # and do the classical post-processing to extract the period of the function f.
-    for _ in range(n_attempts):
-        try:
-            x1, x2 = iteration().int_outcomes().keys()
-        except ValueError:  # identical results, skip
-            continue
-
-        m = num_qubits // 2
-
-        k1 = Fraction(x1, 2**num_qubits).limit_denominator(2**m - 1)
-        k2 = Fraction(x2, 2**num_qubits).limit_denominator(2**m - 1)
-
-        b1 = k1.denominator
-        b2 = k2.denominator
-
-        r = int(np.lcm(b1, b2))
-        results.append(f(r) == f(0))
-
-    # more than 50% of the attempts were successful
-    assert len(results) > n_attempts * 0.5
-
-    # got the right result more than 50% of the successful attempts
-    # this is quite loose, but doing more iterations would be annoyingly long on CI
-    assert np.count_nonzero(results) > len(results) * 0.5

--- a/test/test_job_persistence.py
+++ b/test/test_job_persistence.py
@@ -13,7 +13,6 @@
 import json
 import os
 import re
-import typing
 import uuid
 from pathlib import Path
 from typing import NamedTuple, Optional
@@ -55,7 +54,7 @@ def test_job_persistence_transaction_offline_simulator(
     assert isinstance(backend, OfflineSimulatorResource)
 
     circuits = [random_circuit(2), random_circuit(3)]
-    job = typing.cast(AQTJob, qiskit.execute(circuits, backend))
+    job = backend.run(qiskit.transpile(circuits, backend))
 
     path = job.persist(store_path=tmp_path)
 
@@ -174,7 +173,7 @@ def test_job_persistence_transaction_online_backend(httpx_mock: HTTPXMock, tmp_p
     # ----------
 
     circuits = [random_circuit(2), random_circuit(3), random_circuit(4)]
-    job = typing.cast(AQTJob, qiskit.execute(circuits, backend, shots=123))
+    job = backend.run(qiskit.transpile(circuits, backend), shots=123)
 
     # sanity checks
     assert uuid.UUID(job.job_id()) in portal_state

--- a/test/test_primitives.py
+++ b/test/test_primitives.py
@@ -167,7 +167,7 @@ def test_operator_estimator_primitive_trivial_pauli_z(
 )
 def test_aqt_sampler_transpilation(theta: float, offline_simulator_no_noise: MockSimulator) -> None:
     """Check that the AQTSampler passes the same circuit to the backend as a call to
-    `qiskit.execute` with the same transpiler call on the bound circuit would.
+    `backend.run` with the same transpiler call on the bound circuit would.
     """
     theta_param = Parameter("θ")
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This patch removes references to the deprecated function `qiskit.execute`.

Fixes #134.

### Details and comments

Extra housekeeping:
- remove flaky tests
- resolves left-over Pydantic2 migration todos.