### PR TITLE
Prepare release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## qiskit-aqt-provider v1.3.0
 
+* Point Qiskit docs link to docs.quantum.ibm.com (#135)
 * Remove references to the deprecated function `qiskit.execute` (#136)
 * Pin Qiskit dependency strictly below 1.0 (#137)
 * Remove the Grover 3-SAT example (#137)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
+## qiskit-aqt-provider v1.3.0
+
 * Remove references to the deprecated function `qiskit.execute` (#136)
+* Pin Qiskit dependency strictly below 1.0 (#137)
+* Remove the Grover 3-SAT example (#137)
 
 ## qiskit-aqt-provider v1.2.0
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,5 +80,5 @@ autodoc_pydantic_field_list_validators = False
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "qiskit": ("https://qiskit.org/documentation/", None),
+    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/0.46", None),
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,9 @@ copyright = "2023, Qiskit and AQT development teams"
 author = "Qiskit and AQT development teams"
 
 # The short X.Y version
-version = "1.2.0"
+version = "1.3.0"
 # The full version, including alpha/beta/rc tags
-release = "1.2.0"
+release = "1.3.0"
 
 extensions = [
     "sphinx.ext.napoleon",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qiskit-aqt-provider"
-version = "1.2.0"
+version = "1.3.0"
 description = "Qiskit provider for AQT backends"
 authors = ["Qiskit Development Team", "Alpine Quantum Technologies GmbH"]
 repository = "https://github.com/qiskit-community/qiskit-aqt-provider"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Prepare release 1.3.0.

Most important change is the pin to Qiskit, such that new unlocked installations don't resolve to Qiskit 1.0.

~~Soft block by #138: we can release without it, but should wait if it can be resolved soon.~~

Resolves #138 
