### PR TITLE
docs: add examples for setting run options in primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Docs: add examples on setting run options in primitives (#156)
 
 ## qiskit-aqt-provider v1.4.0
 

--- a/qiskit_aqt_provider/primitives/estimator.py
+++ b/qiskit_aqt_provider/primitives/estimator.py
@@ -33,6 +33,9 @@ class AQTEstimator(BackendEstimator):
     ):
         """Initialize an ``Estimator`` primitive using an AQT backend.
 
+        See :class:`AQTSampler <qiskit_aqt_provider.primitives.sampler.AQTSampler>` for
+        examples configuring run options.
+
         Args:
             backend: AQT resource to evaluate circuits on.
             options: options passed to through to the underlying

--- a/qiskit_aqt_provider/primitives/sampler.py
+++ b/qiskit_aqt_provider/primitives/sampler.py
@@ -38,6 +38,47 @@ class AQTSampler(BackendSampler):
               :class:`BackendSampler <qiskit.primitives.BackendSampler>`.
             skip_transpilation: if :data:`True`, do not transpile circuits
               before passing them to the execution backend.
+
+        Examples:
+            Initialize a :class:`Sampler <qiskit.primitives.BaseSamplerV1>` primitive
+            on a AQT offline simulator:
+
+            >>> import qiskit
+            >>> from qiskit_aqt_provider import AQTProvider
+            >>> from qiskit_aqt_provider.primitives import AQTSampler
+            >>>
+            >>> backend = AQTProvider("").get_backend("offline_simulator_no_noise")
+            >>> sampler = AQTSampler(backend)
+
+            Configuring :class:`options <qiskit_aqt_provider.aqt_options.AQTOptions>`
+            on the backend will affect all circuit evaluations triggered by
+            the `Sampler` primitive:
+
+            >>> qc = qiskit.QuantumCircuit(2)
+            >>> _ = qc.cx(0, 1)
+            >>> _ = qc.measure_all()
+            >>>
+            >>> sampler.run(qc).result().metadata[0]["shots"]
+            100
+            >>> backend.options.shots = 123
+            >>> sampler.run(qc).result().metadata[0]["shots"]
+            123
+
+            The same effect is achieved by passing options to the
+            :class:`AQTSampler` initializer:
+
+            >>> sampler = AQTSampler(backend, options={"shots": 120})
+            >>> sampler.run(qc).result().metadata[0]["shots"]
+            120
+
+            Passing the option in the
+            :meth:`AQTSampler.run <qiskit.primitives.BaseSamplerV1.run>` call
+            restricts the effect to a single evaluation:
+
+            >>> sampler.run(qc, shots=130).result().metadata[0]["shots"]
+            130
+            >>> sampler.run(qc).result().metadata[0]["shots"]
+            120
         """
         # Signal the transpiler to disable passes that require bound
         # parameters.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Add detailed examples on setting run options (example with `shots`) in Qiskit primitives.
