### PR TITLE
Prepare release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## qiskit-aqt-provider v1.5.0
 
 * Docs: add examples on setting run options in primitives (#156)
 * Provider: remove `ProviderV1` inheritance (#160)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,9 @@ copyright = "2023, Qiskit and AQT development teams"
 author = "Qiskit and AQT development teams"
 
 # The short X.Y version
-version = "1.4.0"
+version = "1.5.0"
 # The full version, including alpha/beta/rc tags
-release = "1.4.0"
+release = "1.5.0"
 
 extensions = [
     "sphinx.ext.napoleon",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "qiskit-aqt-provider"
-version = "1.4.0"
+version = "1.5.0"
 description = "Qiskit provider for AQT backends"
 authors = [
   "Qiskit Development Team",


### PR DESCRIPTION
### Summary

Prepare release 1.5.0.


### Details and comments

* Docs: add examples on setting run options in primitives (#156)
* Provider: remove `ProviderV1` inheritance (#160)