### PR TITLE
Propagate query_timeout_seconds option for direct-access jobs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Support direct-access mode on AQT devices (#164)
 * Support up to 2000 shots per circuit on cloud resources (#165)
+* Fix result timeout propagation in direct-access mode (#171)
 
 ## qiskit-aqt-provider v1.5.0
 

--- a/qiskit_aqt_provider/aqt_job.py
+++ b/qiskit_aqt_provider/aqt_job.py
@@ -447,7 +447,9 @@ class AQTDirectAccessJob(JobV1):
             for circuit_index, circuit in enumerate(self.circuits):
                 api_circuit = self.api_submit_payload.payload.circuits[circuit_index]
                 job_id = self._backend.submit(api_circuit)
-                api_result = self._backend.result(job_id)
+                api_result = self._backend.result(
+                    job_id, timeout=self.options.query_timeout_seconds
+                )
 
                 if isinstance(api_result.payload, JobResultError):
                     break

--- a/qiskit_aqt_provider/aqt_resource.py
+++ b/qiskit_aqt_provider/aqt_resource.py
@@ -337,18 +337,19 @@ class AQTDirectAccessResource(_ResourceBase[AQTDirectAccessOptions]):
         resp.raise_for_status()
         return UUID(resp.json())
 
-    def result(self, job_id: UUID) -> api_models_direct.JobResult:
+    def result(self, job_id: UUID, *, timeout: Optional[float]) -> api_models_direct.JobResult:
         """Query the result of a specific job.
 
         Block until a result (success or error) is available.
 
         Args:
             job_id: unique identifier of the target job.
+            timeout: query timeout, in seconds. Disabled if `None`.
 
         Returns:
             Job result, as API payload.
         """
-        resp = self._http_client.get(f"/circuit/result/{job_id}")
+        resp = self._http_client.get(f"/circuit/result/{job_id}", timeout=timeout)
         resp.raise_for_status()
         return api_models_direct.JobResult.model_validate(resp.json())
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Propagate the `query_timeout_seconds` option to direct-access jobs. Since the default value is `None`, it disables the HTTP read timeout.

Resolves #168.

### Details and comments

The option propagation is not tested because this would require setting up an async test case (to not block in the mocked response), leading to all sorts of problems because the `httpx` client in `AQTDirectAccessResource` is the synchronous one.