### PR TITLE
Update API specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Update API specification and associated constraints (#176)
+
 ## qiskit-aqt-provider v1.6.0
 
 * Support direct-access mode on AQT devices (#164)

--- a/api/aqt_public.yml
+++ b/api/aqt_public.yml
@@ -69,7 +69,7 @@ components:
       type: object
     GateRXX:
       additionalProperties: false
-      description: "### A two-qubit entangling gate of M\xF8lmer-S\xF8renson-type.\n\
+      description: "### A two-qubit entangling gate of M\xF8lmer-S\xF8rensen-type.\n\
         \nThe MS-gate on qubits j and k with pulse area \u03B8 in units of \u03C0\
         \ is defined as\n    $$\n    \\begin{aligned}\n    U_{\\mathrm{MS}}^{j,k}\
         \ \\left (\\theta \\right) & =\n    e^{\\mathrm{i}\\theta\\frac{\\pi}{2}}\\\
@@ -805,7 +805,7 @@ info:
   description: "\n## AQT Quantum Gates\nThe available quantum gate set for AQT backends\
     \ consists of the following gates:\n\n* R-gate - rotation around an arbitrary\
     \ axis on the Bloch sphere's equatorial plane\n* Rz-gate - rotation around the\
-    \ Bloch sphere's z-axis\n* MS-gate - entangling gate of M\xF8lmer-S\xF8renson-type\n\
+    \ Bloch sphere's z-axis\n* MS-gate - entangling gate of M\xF8lmer-S\xF8rensen-type\n\
     \nAll quantum gates are defined in terms of the Pauli matrices $\n    \\sigma_x\
     \ =\n    \\begin{pmatrix}\n    0 & 1 \\\\ 1 & 0\n    \\end{pmatrix}\n$, $\n  \
     \ \\sigma_y =\n    \\begin{pmatrix}\n    0 & -\\mathrm{i} \\\\ \\mathrm{i} & 0\n\

--- a/api/aqt_public.yml
+++ b/api/aqt_public.yml
@@ -18,15 +18,29 @@ components:
         - operation: MEASURE
       items:
         $ref: '#/components/schemas/OperationModel'
-      maxItems: 10000
+      maxItems: 2500
       minItems: 1
       title: Circuit
       type: array
     GateR:
       additionalProperties: false
-      description: "A single-qubit rotation.\n\nDescribes a rotation of angle \u03B8\
-        \ around axis \u03C6 in the equatorial plane of the Bloch sphere.\n\nAngles\
-        \ are expressed in units of \u03C0."
+      description: "### A single-qubit rotation around an arbitrary axis on the Bloch\
+        \ sphere's equatorial plane.\n\nThe R-gate on qubit j with pulse area \u03B8\
+        \ and mixing angle \u03C6, both in units of \u03C0, is defined as\n    $$\n\
+        \    U_{\\mathrm{R}}^j(\\theta,\\varphi) =\n    \\exp\\left( -\\mathrm{i}\
+        \ \\theta \\frac{\\pi}{2}\n    \\left[\\sin(\\varphi \\pi)\\sigma_y^j + \\\
+        cos(\\varphi \\pi)\\sigma_x^j \\right] \\right) =\n    \\begin{pmatrix}\n\
+        \    \\cos(\\theta \\frac{\\pi}{2}) && -\\mathrm{i} e^{-\\mathrm{i} \\varphi\
+        \ \\pi}\\sin(\\theta \\frac{\\pi}{2})\\\\\n    -\\mathrm{i} e^{\\mathrm{i}\
+        \ \\varphi \\pi}\\sin(\\theta \\frac{\\pi}{2}) && \\cos(\\theta \\frac{\\\
+        pi}{2})\n    \\end{pmatrix}\n    $$\nwith the Pauli matrices\n    $$\n   \
+        \ \\sigma_x =\n    \\begin{pmatrix}\n    0 & 1 \\\\ 1 & 0\n    \\end{pmatrix}\
+        \ ,\n    \\sigma_y =\n    \\begin{pmatrix}\n    0 & -\\mathrm{i} \\\\ \\mathrm{i}\
+        \ & 0\n    \\end{pmatrix}.\n    $$\n\n**Examples:**\n    $$\n    \\begin{align*}\n\
+        \    U_{\\mathrm{R}}^j(0.5, 0) \\ket{0_j} &=\n    \\frac{1}{\\sqrt{2}}\\left\
+        \ (\\ket{0_j} - \\mathrm{i}\\ket{1_j} \\right )\\\\\n    U_{\\mathrm{R}}^j(0.5,\
+        \ 0.5) \\ket{0_j} &=\n    \\frac{1}{\\sqrt{2}}\\left (\\ket{0_j} + \\ket{1_j}\
+        \ \\right )\n    \\end{align*}\n    $$"
       properties:
         operation:
           const: R
@@ -55,9 +69,29 @@ components:
       type: object
     GateRXX:
       additionalProperties: false
-      description: "A parametric 2-qubits X\u2297X gate with angle \u03B8.\n\nThe\
-        \ angle is expressed in units of \u03C0. The gate is maximally entangling\n\
-        for \u03B8=0.5 (\u03C0/2)."
+      description: "### A two-qubit entangling gate of M\xF8lmer-S\xF8renson-type.\n\
+        \nThe MS-gate on qubits j and k with pulse area \u03B8 in units of \u03C0\
+        \ is defined as\n    $$\n    \\begin{aligned}\n    U_{\\mathrm{MS}}^{j,k}\
+        \ \\left (\\theta \\right) & =\n    e^{\\mathrm{i}\\theta\\frac{\\pi}{2}}\\\
+        exp{\\left(-\\mathrm{i} \\theta \\pi {S_x}^2 \\right) }\n    = \\begin{pmatrix}\n\
+        \    \\cos(\\theta \\frac{\\pi}{2}) & 0 & 0 && -\\mathrm{i}\\sin(\\theta \\\
+        frac{\\pi}{2}) \\\\\n    0 & \\cos(\\theta \\frac{\\pi}{2}) & -\\mathrm{i}\\\
+        sin(\\theta \\frac{\\pi}{2}) && 0 \\\\\n    0 & -\\mathrm{i}\\sin(\\theta\\\
+        frac{\\pi}{2}) & \\cos(\\theta \\frac{\\pi}{2}) && 0 \\\\\n    -\\mathrm{i}\\\
+        sin(\\theta \\frac{\\pi}{2}) & 0 & 0 && \\cos(\\theta \\frac{\\pi}{2})\n \
+        \   \\end{pmatrix}\n    \\end{aligned}\n    $$\nwith\n    $$\n    S_x =\\\
+        frac{1}{2}\\left (\\sigma_x^j + \\sigma_x^k \\right)\n    $$\nand the Pauli\
+        \ matrix\n    $$\n    \\sigma_x =\n    \\begin{pmatrix}\n    0 & 1 \\\\ 1\
+        \ & 0\n    \\end{pmatrix}.\n    $$\n\nA fully-entangling gate between qubit\
+        \ 0 and qubit 1 therefore is\n    $$\n    U_{\\mathrm{MS}}^{0,1} \\left (0.5\
+        \ \\right) = \\frac{1}{\\sqrt{2}}\n    \\begin{pmatrix}\n    1 && 0 && 0 &&\
+        \ -\\mathrm{i} \\\\ 0 && 1 && -\\mathrm{i} && 0 \\\\\n    0 && -\\mathrm{i}\
+        \ && 1 && 0 \\\\ -\\mathrm{i} && 0 && 0 && 1\n    \\end{pmatrix}\n    $$\n\
+        \n**Examples:**\n    $$\n    \\begin{align*}\n    U_{\\mathrm{MS}}^{j,k}(0.5)\
+        \ \\ket{0_j0_k} &=\n    \\frac{1}{\\sqrt{2}}\\left (\\ket{0_j0_k} -\\mathrm{i}\
+        \ \\ket{1_j1_k} \\right ) \\\\\n    U_{\\mathrm{MS}}^{j,k}(0.5) \\ket{1_j1_k}\
+        \ &=\n    \\frac{1}{\\sqrt{2}}\\left ( -\\mathrm{i}\\ket{0_j0_k} + \\ket{1_j1_k}\
+        \ \\right )\n    \\end{align*}\n    $$"
       properties:
         operation:
           const: RXX
@@ -84,8 +118,20 @@ components:
       type: object
     GateRZ:
       additionalProperties: false
-      description: "A single-qubit rotation of angle \u03C6 around the Z axis of the\
-        \ Bloch sphere."
+      description: "### A single-qubit rotation rotation around the Bloch sphere's\
+        \ z-axis.\n\nThe Rz-gate on qubit j with pulse area \u03B8 in units of \u03C0\
+        \ is defined as\n    $$\n    U_{\\mathrm{R_z}}^j(\\theta) =\n    \\exp\\left(\
+        \ -\\mathrm{i} \\theta \\frac{\\pi}{2} \\sigma_z^j \\right) =\n    \\begin{pmatrix}\n\
+        \    \\cos(\\theta \\frac{\\pi}{2}) -\\mathrm{i}\\sin(\\theta \\frac{\\pi}{2})\
+        \ && 0 \\\\\n    0 && \\cos(\\theta \\frac{\\pi}{2}) +\\mathrm{i}\\sin(\\\
+        theta \\frac{\\pi}{2})\n    \\end{pmatrix}\n    $$\nwith the Pauli matrix\n\
+        \    $$\n    \\sigma_z =\n    \\begin{pmatrix}\n    1 & 0 \\\\ 0 & -1\n  \
+        \  \\end{pmatrix}.\n    $$\n\n**Examples:**\n    $$\n    \\begin{align*}\n\
+        \    U_{\\mathrm{R_z}}^j(1)\\frac{1}{\\sqrt{2}}\\left( \\ket{0_j} + \\ket{1_j}\\\
+        right) &=\n    \\frac{1}{\\sqrt{2}}\\left (\\ket{0_j} - \\ket{1_j} \\right\
+        \ ) \\\\\n    U_{\\mathrm{R_z}}^j(0.5)\\frac{1}{\\sqrt{2}}\\left (\\ket{0_j}\
+        \ + \\ket{1_j} \\right) &=\n    \\frac{1}{\\sqrt{2}}\\left (\\ket{0_j} +\\\
+        mathrm{i}\\ket{1_j} \\right )\n    \\end{align*}\n    $$"
       properties:
         operation:
           const: RZ
@@ -168,51 +214,13 @@ components:
       - response
       title: JobResponse[RRQueued]
       type: object
-    JobSubmission:
-      examples:
-      - job_type: quantum_circuit
-        label: Example computation
-        payload:
-          circuits:
-          - number_of_qubits: 2
-            quantum_circuit:
-            - operation: RZ
-              phi: 0.5
-              qubit: 0
-            - operation: R
-              phi: 0.25
-              qubit: 1
-              theta: 0.5
-            - operation: RXX
-              qubits:
-              - 0
-              - 1
-              theta: 0.5
-            - operation: MEASURE
-            repetitions: 5
-      properties:
-        job_type:
-          const: quantum_circuit
-          default: quantum_circuit
-          title: Job Type
-        label:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Label
-        payload:
-          $ref: '#/components/schemas/QuantumCircuits'
-      required:
-      - payload
-      title: JobSubmission
-      type: object
     JobUser:
       examples:
       - job_id: ccaa39de-d0f3-4c8b-bdb1-4d74f0c2f450
         job_type: quantum_circuit
         label: Example computation
-        resource_id: ''
-        workspace_id: ''
+        resource_id: simulator
+        workspace_id: default
       properties:
         job_id:
           description: Id that uniquely identifies the job. This is used to request
@@ -299,13 +307,15 @@ components:
         repetitions: 5
       properties:
         number_of_qubits:
-          exclusiveMinimum: 0.0
+          maximum: 20.0
+          minimum: 1.0
           title: Number Of Qubits
           type: integer
         quantum_circuit:
           $ref: '#/components/schemas/Circuit'
         repetitions:
-          exclusiveMinimum: 0.0
+          maximum: 2000.0
+          minimum: 1.0
           title: Repetitions
           type: integer
       required:
@@ -338,6 +348,7 @@ components:
         circuits:
           items:
             $ref: '#/components/schemas/QuantumCircuit'
+          maxItems: 50
           minItems: 1
           title: Circuits
           type: array
@@ -472,6 +483,42 @@ components:
       - type
       title: Resource
       type: object
+    ResourceDetails:
+      description: Schema for the response of the public resource details endpoint.
+      properties:
+        available_qubits:
+          title: Available Qubits
+          type: integer
+        id:
+          title: Id
+          type: string
+        name:
+          title: Name
+          type: string
+        status:
+          $ref: '#/components/schemas/ResourceStates'
+        type:
+          enum:
+          - simulator
+          - device
+          title: Type
+          type: string
+      required:
+      - id
+      - name
+      - type
+      - status
+      - available_qubits
+      title: ResourceDetails
+      type: object
+    ResourceStates:
+      description: Possible states of a quantum resource.
+      enum:
+      - online
+      - maintenance
+      - offline
+      title: ResourceStates
+      type: string
     ResultResponse:
       anyOf:
       - $ref: '#/components/schemas/JobResponse_RRQueued_'
@@ -639,6 +686,57 @@ components:
           job_id: 3aa8b827-4ff0-4a36-b1a6-f9ff6dee59ce
           message: unknown job_id
       title: ResultResponse
+    SubmitJobRequest:
+      description: Schema for the request for the public submit job endpoint.
+      examples:
+      - job_type: quantum_circuit
+        label: Example computation
+        payload:
+          circuits:
+          - number_of_qubits: 2
+            quantum_circuit:
+            - operation: RZ
+              phi: 0.5
+              qubit: 0
+            - operation: R
+              phi: 0.25
+              qubit: 1
+              theta: 0.5
+            - operation: RXX
+              qubits:
+              - 0
+              - 1
+              theta: 0.5
+            - operation: MEASURE
+            repetitions: 5
+      properties:
+        job_type:
+          const: quantum_circuit
+          default: quantum_circuit
+          title: Job Type
+        label:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Label
+        payload:
+          $ref: '#/components/schemas/QuantumCircuits'
+      required:
+      - payload
+      title: SubmitJobRequest
+      type: object
+    SubmitJobResponse:
+      description: Schema for the response for the public submit job endpoint.
+      properties:
+        job:
+          $ref: '#/components/schemas/JobUser'
+        response:
+          $ref: '#/components/schemas/RRQueued'
+      required:
+      - job
+      - response
+      title: SubmitJobResponse
+      type: object
     UnknownJob:
       properties:
         job_id:
@@ -704,6 +802,16 @@ components:
       scheme: bearer
       type: http
 info:
+  description: "\n## AQT Quantum Gates\nThe available quantum gate set for AQT backends\
+    \ consists of the following gates:\n\n* R-gate - rotation around an arbitrary\
+    \ axis on the Bloch sphere's equatorial plane\n* Rz-gate - rotation around the\
+    \ Bloch sphere's z-axis\n* MS-gate - entangling gate of M\xF8lmer-S\xF8renson-type\n\
+    \nAll quantum gates are defined in terms of the Pauli matrices $\n    \\sigma_x\
+    \ =\n    \\begin{pmatrix}\n    0 & 1 \\\\ 1 & 0\n    \\end{pmatrix}\n$, $\n  \
+    \ \\sigma_y =\n    \\begin{pmatrix}\n    0 & -\\mathrm{i} \\\\ \\mathrm{i} & 0\n\
+    \    \\end{pmatrix}\n$ and $\\sigma_z =\n    \\begin{pmatrix}\n    1 & 0 \\\\\
+    \ 0 & -1\n    \\end{pmatrix}.\n$\n\nThe formal definitions of the gates can be\
+    \ found in their respective schema descriptions.\n"
   title: AQT Public API
   version: 0.4.0
 openapi: 3.1.0
@@ -720,7 +828,7 @@ paths:
 
 
         Any results already processed will not be deleted.'
-      operationId: cancel_job_jobs__job_id__delete
+      operationId: cancel_job_handler_jobs__job_id__delete
       parameters:
       - in: path
         name: job_id
@@ -746,7 +854,42 @@ paths:
           description: Validation Error
       security:
       - Bearer Token: []
-      summary: Cancel Job
+      summary: Cancel Job Handler
+      tags:
+      - jobs
+  /resources/{resource_id}:
+    get:
+      description: Provides details for the resource identified by 'resource_id'
+      operationId: get_resource_resources__resource_id__get
+      parameters:
+      - in: path
+        name: resource_id
+        required: true
+        schema:
+          title: Resource Id
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceDetails'
+          description: Information about the resource
+        '401':
+          description: Unauthorized
+        '403':
+          description: Resource not available.
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - Bearer Token: []
+      summary: Get Resource
+      tags:
+      - resources
   /result/{job_id}:
     get:
       description: Request job results
@@ -960,14 +1103,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/JobSubmission'
+              $ref: '#/components/schemas/SubmitJobRequest'
         required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JobResponse_RRQueued_'
+                $ref: '#/components/schemas/SubmitJobResponse'
           description: Successful Response
         '401':
           description: Unauthorized

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,9 +114,6 @@ examples = [
 [tool.ruff]
 target-version = "py39"
 line-length = 100
-extend-exclude = [
-  "qiskit_aqt_provider/api_models_generated.py", # generated code
-]
 
 lint.select = [
   "ANN",  # flake8-annotations
@@ -183,6 +180,13 @@ lint.ignore = [
 ]
 lint.per-file-ignores."examples/*.py" = [
   "T201", # allow prints
+]
+lint.per-file-ignores."qiskit_aqt_provider/api_models_generated.py" = [
+  "D100",   # undocumented-public-module
+  "D101",   # undocumented-public-class
+  "E501",   # line-too-long
+  "ERA001", # commented-out-code
+  "UP",     # pyupgrade
 ]
 lint.per-file-ignores."scripts/*.py" = [
   "T201", # allow prints

--- a/qiskit_aqt_provider/api_models.py
+++ b/qiskit_aqt_provider/api_models.py
@@ -25,10 +25,10 @@ from typing_extensions import Self, TypeAlias
 from qiskit_aqt_provider import api_models_generated as api_models
 from qiskit_aqt_provider.api_models_generated import (
     Circuit,
-    JobSubmission,
     OperationModel,
     QuantumCircuit,
     QuantumCircuits,
+    SubmitJobRequest,
 )
 from qiskit_aqt_provider.api_models_generated import Type as ResourceType
 from qiskit_aqt_provider.versions import USER_AGENT
@@ -36,7 +36,7 @@ from qiskit_aqt_provider.versions import USER_AGENT
 __all__ = [
     "Circuit",
     "JobResponse",
-    "JobSubmission",
+    "SubmitJobRequest",
     "Operation",
     "OperationModel",
     "QuantumCircuit",

--- a/qiskit_aqt_provider/api_models_generated.py
+++ b/qiskit_aqt_provider/api_models_generated.py
@@ -64,7 +64,7 @@ class Qubit(RootModel[int]):
 
 
 class GateRXX(BaseModel):
-    r"""### A two-qubit entangling gate of Mølmer-Sørenson-type.
+    r"""### A two-qubit entangling gate of Mølmer-Sørensen-type.
 
     The MS-gate on qubits j and k with pulse area θ in units of π is defined as
         $$

--- a/qiskit_aqt_provider/api_models_generated.py
+++ b/qiskit_aqt_provider/api_models_generated.py
@@ -11,8 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, RootModel
 
 
 class GateR(BaseModel):
-    """
-    ### A single-qubit rotation around an arbitrary axis on the Bloch sphere's equatorial plane.
+    r"""### A single-qubit rotation around an arbitrary axis on the Bloch sphere's equatorial plane.
 
     The R-gate on qubit j with pulse area θ and mixing angle φ, both in units of π, is defined as
         $$
@@ -65,8 +64,7 @@ class Qubit(RootModel[int]):
 
 
 class GateRXX(BaseModel):
-    """
-    ### A two-qubit entangling gate of Mølmer-Sørenson-type.
+    r"""### A two-qubit entangling gate of Mølmer-Sørenson-type.
 
     The MS-gate on qubits j and k with pulse area θ in units of π is defined as
         $$
@@ -123,8 +121,7 @@ class GateRXX(BaseModel):
 
 
 class GateRZ(BaseModel):
-    """
-    ### A single-qubit rotation rotation around the Bloch sphere's z-axis.
+    r"""### A single-qubit rotation rotation around the Bloch sphere's z-axis.
 
     The Rz-gate on qubit j with pulse area θ in units of π is defined as
         $$
@@ -171,17 +168,14 @@ class JobUser(BaseModel):
     """
     Id that uniquely identifies the job. This is used to request results.
     """
-    job_type: Annotated[
-        Literal["quantum_circuit"], Field("quantum_circuit", title="Job Type")
-    ]
+    job_type: Annotated[Literal["quantum_circuit"], Field("quantum_circuit", title="Job Type")]
     label: Annotated[Optional[str], Field(None, title="Label")]
     resource_id: Annotated[str, Field("", title="Resource Id")]
     workspace_id: Annotated[str, Field("", title="Workspace Id")]
 
 
 class Measure(BaseModel):
-    """
-    Measurement operation.
+    """Measurement operation.
 
     The MEASURE operation instructs the resource
     to perform a projective measurement of all qubits.
@@ -233,9 +227,7 @@ class ResultItem(RootModel[int]):
 
 
 class RRFinished(BaseModel):
-    """
-    Contains the measurement data of a finished circuit.
-    """
+    """Contains the measurement data of a finished circuit."""
 
     model_config = ConfigDict(
         frozen=True,
@@ -274,9 +266,7 @@ class Resource(BaseModel):
 
 
 class ResourceStates(Enum):
-    """
-    Possible states of a quantum resource.
-    """
+    """Possible states of a quantum resource."""
 
     online = "online"
     maintenance = "maintenance"
@@ -284,9 +274,7 @@ class ResourceStates(Enum):
 
 
 class SubmitJobResponse(BaseModel):
-    """
-    Schema for the response for the public submit job endpoint.
-    """
+    """Schema for the response for the public submit job endpoint."""
 
     model_config = ConfigDict(
         frozen=True,
@@ -300,9 +288,7 @@ class UnknownJob(BaseModel):
         frozen=True,
     )
     job_id: Annotated[UUID, Field(title="Job Id")]
-    message: Annotated[
-        Literal["unknown job_id"], Field("unknown job_id", title="Message")
-    ]
+    message: Annotated[Literal["unknown job_id"], Field("unknown job_id", title="Message")]
 
 
 class ValidationError(BaseModel):
@@ -323,9 +309,7 @@ class Workspace(BaseModel):
 
 
 class Circuit(RootModel[List[OperationModel]]):
-    """
-    Json encoding of a quantum circuit.
-    """
+    """Json encoding of a quantum circuit."""
 
     model_config = ConfigDict(
         frozen=True,
@@ -399,9 +383,7 @@ class JobResponseRRQueued(BaseModel):
 
 
 class QuantumCircuit(BaseModel):
-    """
-    A quantum circuit-type job that can run on a computing resource.
-    """
+    """A quantum circuit-type job that can run on a computing resource."""
 
     model_config = ConfigDict(
         frozen=True,
@@ -412,22 +394,16 @@ class QuantumCircuit(BaseModel):
 
 
 class QuantumCircuits(BaseModel):
-    """
-    A collection of quantum circuits representing a single job.
-    """
+    """A collection of quantum circuits representing a single job."""
 
     model_config = ConfigDict(
         frozen=True,
     )
-    circuits: Annotated[
-        List[QuantumCircuit], Field(max_length=50, min_length=1, title="Circuits")
-    ]
+    circuits: Annotated[List[QuantumCircuit], Field(max_length=50, min_length=1, title="Circuits")]
 
 
 class ResourceDetails(BaseModel):
-    """
-    Schema for the response of the public resource details endpoint.
-    """
+    """Schema for the response of the public resource details endpoint."""
 
     model_config = ConfigDict(
         frozen=True,
@@ -467,8 +443,7 @@ class ResultResponse(
             examples=[
                 {
                     "description": (
-                        "Job waiting in the queue to be picked up by the Quantum"
-                        " computer"
+                        "Job waiting in the queue to be picked up by the Quantum" " computer"
                     ),
                     "summary": "Queued Job",
                     "value": {
@@ -542,8 +517,7 @@ class ResultResponse(
                 },
                 {
                     "description": (
-                        "Job that created an error while being processed by the Quantum"
-                        " computer"
+                        "Job that created an error while being processed by the Quantum" " computer"
                     ),
                     "summary": "Failed Job",
                     "value": {
@@ -675,15 +649,11 @@ class ResultResponse(
 
 
 class SubmitJobRequest(BaseModel):
-    """
-    Schema for the request for the public submit job endpoint.
-    """
+    """Schema for the request for the public submit job endpoint."""
 
     model_config = ConfigDict(
         frozen=True,
     )
-    job_type: Annotated[
-        Literal["quantum_circuit"], Field("quantum_circuit", title="Job Type")
-    ]
+    job_type: Annotated[Literal["quantum_circuit"], Field("quantum_circuit", title="Job Type")]
     label: Annotated[Optional[str], Field(None, title="Label")]
     payload: QuantumCircuits

--- a/qiskit_aqt_provider/api_models_generated.py
+++ b/qiskit_aqt_provider/api_models_generated.py
@@ -12,11 +12,39 @@ from pydantic import BaseModel, ConfigDict, Field, RootModel
 
 class GateR(BaseModel):
     """
-    A single-qubit rotation.
+    ### A single-qubit rotation around an arbitrary axis on the Bloch sphere's equatorial plane.
 
-    Describes a rotation of angle θ around axis φ in the equatorial plane of the Bloch sphere.
+    The R-gate on qubit j with pulse area θ and mixing angle φ, both in units of π, is defined as
+        $$
+        U_{\mathrm{R}}^j(\theta,\varphi) =
+        \exp\left( -\mathrm{i} \theta \frac{\pi}{2}
+        \left[\sin(\varphi \pi)\sigma_y^j + \cos(\varphi \pi)\sigma_x^j \right] \right) =
+        \begin{pmatrix}
+        \cos(\theta \frac{\pi}{2}) && -\mathrm{i} e^{-\mathrm{i} \varphi \pi}\sin(\theta \frac{\pi}{2})\\
+        -\mathrm{i} e^{\mathrm{i} \varphi \pi}\sin(\theta \frac{\pi}{2}) && \cos(\theta \frac{\pi}{2})
+        \end{pmatrix}
+        $$
+    with the Pauli matrices
+        $$
+        \sigma_x =
+        \begin{pmatrix}
+        0 & 1 \\ 1 & 0
+        \end{pmatrix} ,
+        \sigma_y =
+        \begin{pmatrix}
+        0 & -\mathrm{i} \\ \mathrm{i} & 0
+        \end{pmatrix}.
+        $$
 
-    Angles are expressed in units of π.
+    **Examples:**
+        $$
+        \begin{align*}
+        U_{\mathrm{R}}^j(0.5, 0) \ket{0_j} &=
+        \frac{1}{\sqrt{2}}\left (\ket{0_j} - \mathrm{i}\ket{1_j} \right )\\
+        U_{\mathrm{R}}^j(0.5, 0.5) \ket{0_j} &=
+        \frac{1}{\sqrt{2}}\left (\ket{0_j} + \ket{1_j} \right )
+        \end{align*}
+        $$
     """
 
     model_config = ConfigDict(
@@ -38,10 +66,51 @@ class Qubit(RootModel[int]):
 
 class GateRXX(BaseModel):
     """
-    A parametric 2-qubits X⊗X gate with angle θ.
+    ### A two-qubit entangling gate of Mølmer-Sørenson-type.
 
-    The angle is expressed in units of π. The gate is maximally entangling
-    for θ=0.5 (π/2).
+    The MS-gate on qubits j and k with pulse area θ in units of π is defined as
+        $$
+        \begin{aligned}
+        U_{\mathrm{MS}}^{j,k} \left (\theta \right) & =
+        e^{\mathrm{i}\theta\frac{\pi}{2}}\exp{\left(-\mathrm{i} \theta \pi {S_x}^2 \right) }
+        = \begin{pmatrix}
+        \cos(\theta \frac{\pi}{2}) & 0 & 0 && -\mathrm{i}\sin(\theta \frac{\pi}{2}) \\
+        0 & \cos(\theta \frac{\pi}{2}) & -\mathrm{i}\sin(\theta \frac{\pi}{2}) && 0 \\
+        0 & -\mathrm{i}\sin(\theta\frac{\pi}{2}) & \cos(\theta \frac{\pi}{2}) && 0 \\
+        -\mathrm{i}\sin(\theta \frac{\pi}{2}) & 0 & 0 && \cos(\theta \frac{\pi}{2})
+        \end{pmatrix}
+        \end{aligned}
+        $$
+    with
+        $$
+        S_x =\frac{1}{2}\left (\sigma_x^j + \sigma_x^k \right)
+        $$
+    and the Pauli matrix
+        $$
+        \sigma_x =
+        \begin{pmatrix}
+        0 & 1 \\ 1 & 0
+        \end{pmatrix}.
+        $$
+
+    A fully-entangling gate between qubit 0 and qubit 1 therefore is
+        $$
+        U_{\mathrm{MS}}^{0,1} \left (0.5 \right) = \frac{1}{\sqrt{2}}
+        \begin{pmatrix}
+        1 && 0 && 0 && -\mathrm{i} \\ 0 && 1 && -\mathrm{i} && 0 \\
+        0 && -\mathrm{i} && 1 && 0 \\ -\mathrm{i} && 0 && 0 && 1
+        \end{pmatrix}
+        $$
+
+    **Examples:**
+        $$
+        \begin{align*}
+        U_{\mathrm{MS}}^{j,k}(0.5) \ket{0_j0_k} &=
+        \frac{1}{\sqrt{2}}\left (\ket{0_j0_k} -\mathrm{i} \ket{1_j1_k} \right ) \\
+        U_{\mathrm{MS}}^{j,k}(0.5) \ket{1_j1_k} &=
+        \frac{1}{\sqrt{2}}\left ( -\mathrm{i}\ket{0_j0_k} + \ket{1_j1_k} \right )
+        \end{align*}
+        $$
     """
 
     model_config = ConfigDict(
@@ -55,7 +124,34 @@ class GateRXX(BaseModel):
 
 class GateRZ(BaseModel):
     """
-    A single-qubit rotation of angle φ around the Z axis of the Bloch sphere.
+    ### A single-qubit rotation rotation around the Bloch sphere's z-axis.
+
+    The Rz-gate on qubit j with pulse area θ in units of π is defined as
+        $$
+        U_{\mathrm{R_z}}^j(\theta) =
+        \exp\left( -\mathrm{i} \theta \frac{\pi}{2} \sigma_z^j \right) =
+        \begin{pmatrix}
+        \cos(\theta \frac{\pi}{2}) -\mathrm{i}\sin(\theta \frac{\pi}{2}) && 0 \\
+        0 && \cos(\theta \frac{\pi}{2}) +\mathrm{i}\sin(\theta \frac{\pi}{2})
+        \end{pmatrix}
+        $$
+    with the Pauli matrix
+        $$
+        \sigma_z =
+        \begin{pmatrix}
+        1 & 0 \\ 0 & -1
+        \end{pmatrix}.
+        $$
+
+    **Examples:**
+        $$
+        \begin{align*}
+        U_{\mathrm{R_z}}^j(1)\frac{1}{\sqrt{2}}\left( \ket{0_j} + \ket{1_j}\right) &=
+        \frac{1}{\sqrt{2}}\left (\ket{0_j} - \ket{1_j} \right ) \\
+        U_{\mathrm{R_z}}^j(0.5)\frac{1}{\sqrt{2}}\left (\ket{0_j} + \ket{1_j} \right) &=
+        \frac{1}{\sqrt{2}}\left (\ket{0_j} +\mathrm{i}\ket{1_j} \right )
+        \end{align*}
+        $$
     """
 
     model_config = ConfigDict(
@@ -177,6 +273,28 @@ class Resource(BaseModel):
     type: Annotated[Type, Field(title="Type")]
 
 
+class ResourceStates(Enum):
+    """
+    Possible states of a quantum resource.
+    """
+
+    online = "online"
+    maintenance = "maintenance"
+    offline = "offline"
+
+
+class SubmitJobResponse(BaseModel):
+    """
+    Schema for the response for the public submit job endpoint.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+    )
+    job: JobUser
+    response: RRQueued
+
+
 class UnknownJob(BaseModel):
     model_config = ConfigDict(
         frozen=True,
@@ -223,7 +341,7 @@ class Circuit(RootModel[List[OperationModel]]):
                     {"operation": "MEASURE"},
                 ]
             ],
-            max_length=10000,
+            max_length=2500,
             min_length=1,
             title="Circuit",
         ),
@@ -288,9 +406,9 @@ class QuantumCircuit(BaseModel):
     model_config = ConfigDict(
         frozen=True,
     )
-    number_of_qubits: Annotated[int, Field(gt=0, title="Number Of Qubits")]
+    number_of_qubits: Annotated[int, Field(ge=1, le=20, title="Number Of Qubits")]
     quantum_circuit: Circuit
-    repetitions: Annotated[int, Field(gt=0, title="Repetitions")]
+    repetitions: Annotated[int, Field(ge=1, le=2000, title="Repetitions")]
 
 
 class QuantumCircuits(BaseModel):
@@ -301,7 +419,24 @@ class QuantumCircuits(BaseModel):
     model_config = ConfigDict(
         frozen=True,
     )
-    circuits: Annotated[List[QuantumCircuit], Field(min_length=1, title="Circuits")]
+    circuits: Annotated[
+        List[QuantumCircuit], Field(max_length=50, min_length=1, title="Circuits")
+    ]
+
+
+class ResourceDetails(BaseModel):
+    """
+    Schema for the response of the public resource details endpoint.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+    )
+    available_qubits: Annotated[int, Field(title="Available Qubits")]
+    id: Annotated[str, Field(title="Id")]
+    name: Annotated[str, Field(title="Name")]
+    status: ResourceStates
+    type: Annotated[Type, Field(title="Type")]
 
 
 class ResultResponse(
@@ -539,7 +674,11 @@ class ResultResponse(
     ]
 
 
-class JobSubmission(BaseModel):
+class SubmitJobRequest(BaseModel):
+    """
+    Schema for the request for the public submit job endpoint.
+    """
+
     model_config = ConfigDict(
         frozen=True,
     )

--- a/qiskit_aqt_provider/circuit_to_aqt.py
+++ b/qiskit_aqt_provider/circuit_to_aqt.py
@@ -114,7 +114,7 @@ def aqt_to_qiskit_circuit(circuit: api_models.Circuit, number_of_qubits: int) ->
     return qiskit_circuit
 
 
-def circuits_to_aqt_job(circuits: list[QuantumCircuit], shots: int) -> api_models.JobSubmission:
+def circuits_to_aqt_job(circuits: list[QuantumCircuit], shots: int) -> api_models.SubmitJobRequest:
     """Convert a list of circuits to the corresponding AQT API job request payload.
 
     Args:
@@ -124,7 +124,7 @@ def circuits_to_aqt_job(circuits: list[QuantumCircuit], shots: int) -> api_model
     Returns:
         JobSubmission: AQT API payload for submitting the quantum circuits job.
     """
-    return api_models.JobSubmission(
+    return api_models.SubmitJobRequest(
         job_type="quantum_circuit",
         label="qiskit",
         payload=api_models.QuantumCircuits(

--- a/scripts/api_models.py
+++ b/scripts/api_models.py
@@ -13,11 +13,11 @@
 
 import shlex
 import subprocess
-import sys
 import tempfile
 from functools import lru_cache
 from pathlib import Path
 
+import tomlkit
 import typer
 
 app = typer.Typer()
@@ -47,25 +47,46 @@ def default_models_path() -> Path:
     return repo_root() / "qiskit_aqt_provider" / "api_models_generated.py"
 
 
-def generate_models(schema_path: Path) -> str:
+def generate_models(schema_path: Path, dest_path: Path, *, ruff_lint_extra_args: str = "") -> None:
     """Generate Pydantic models from a given schema.
 
     Args:
         schema_path: path to the file that contains the schema.
+        dest_path: path to the file to write the generated models to.
+        ruff_lint_extra_args: extra command-line arguments passed to the ruff linter.
+
+    """
+    dest_path.write_text(run_command(f"datamodel-codegen --input {schema_path}"))
+    # First optimistically fix pydocstyle errors.
+    # Addresses in particular D301 (escape-sequence-in-docstring).
+    run_command(f"ruff check --fix --unsafe-fixes --select D {ruff_lint_extra_args} {dest_path}")
+    run_command(f"ruff check {ruff_lint_extra_args} --fix {dest_path}")
+    run_command(f"ruff format {dest_path}")
+
+
+def run_command(cmd: str) -> str:
+    """Run a command as subprocess.
+
+    Args:
+        cmd: command to execute.
 
     Returns:
-        Source code of the Pydantic models.
+        Content of the standard output produced by the command.
+
+    Raises:
+        typer.Exit: the command failed. The exit status code is 1.
     """
     try:
         proc = subprocess.run(
-            shlex.split(f"datamodel-codegen --input {schema_path}"),  # noqa: S603
-            capture_output=True,
+            shlex.split(cmd),  # noqa: S603
             check=True,
+            capture_output=True,
         )
     except subprocess.CalledProcessError as e:
+        print(e.stdout.decode())
         print(e.stderr.decode())
         print("-------------------------------------------------")
-        print(f"datamodel-codegen failed with error code: {e.returncode}")
+        print(f"'{cmd}' failed with error code: {e.returncode}")
         raise typer.Exit(code=1)
 
     return proc.stdout.decode()
@@ -84,7 +105,7 @@ def generate(
         schema_path: path to the file that contains the schema
         models_path: path of the file to write the generated models to.
     """
-    models_path.write_text(generate_models(schema_path))
+    generate_models(schema_path, models_path)
 
 
 @app.command()
@@ -97,20 +118,19 @@ def check(
     For the check to succeed, `models_path` must contain exactly what the
     generator produces with `schema_path` as input.
     """
+    # Retrieve target-file-specific ignored linter rules.
+    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+    pyproject = tomlkit.parse(pyproject_path.read_text())
+    ignored_rules = pyproject["tool"]["ruff"]["lint"]["per-file-ignores"][  # type: ignore[index]
+        str(models_path.relative_to(pyproject_path.parent))
+    ]
+    ruff_lint_extra_args = f"--ignore {','.join(ignored_rules)}"  # type: ignore[arg-type]
+
     with tempfile.NamedTemporaryFile(mode="w") as reference_models:
         filepath = Path(reference_models.name)
-        filepath.write_text(generate_models(schema_path))
+        generate_models(schema_path, filepath, ruff_lint_extra_args=ruff_lint_extra_args)
 
-        proc = subprocess.run(
-            shlex.split(f"diff -u {filepath} {models_path}"),  # noqa: S603
-            capture_output=True,
-            check=True,
-        )
-
-        if proc.returncode != 0:
-            print(proc.stdout.decode())
-            sys.exit(proc.returncode)
-
+        run_command(f"diff -u {filepath} {models_path}")
         print("OK")
 
 

--- a/test/test_circuit_to_aqt.py
+++ b/test/test_circuit_to_aqt.py
@@ -54,7 +54,7 @@ def test_just_measure_circuit() -> None:
     qc = QuantumCircuit(1)
     qc.measure_all()
 
-    expected = api_models.JobSubmission(
+    expected = api_models.SubmitJobRequest(
         job_type="quantum_circuit",
         label="qiskit",
         payload=api_models.QuantumCircuits(
@@ -83,7 +83,7 @@ def test_valid_circuit() -> None:
 
     result = circuits_to_aqt_job([qc], shots=1)
 
-    expected = api_models.JobSubmission(
+    expected = api_models.SubmitJobRequest(
         job_type="quantum_circuit",
         label="qiskit",
         payload=api_models.QuantumCircuits(
@@ -138,7 +138,7 @@ def test_invalid_measurements() -> None:
     qc.measure([1], [1])
 
     result = circuits_to_aqt_job([qc], shots=1)
-    expected = api_models.JobSubmission(
+    expected = api_models.SubmitJobRequest(
         job_type="quantum_circuit",
         label="qiskit",
         payload=api_models.QuantumCircuits(
@@ -174,7 +174,7 @@ def test_convert_multiple_circuits() -> None:
 
     result = circuits_to_aqt_job([qc0, qc1], shots=1)
 
-    expected = api_models.JobSubmission(
+    expected = api_models.SubmitJobRequest(
         job_type="quantum_circuit",
         label="qiskit",
         payload=api_models.QuantumCircuits(

--- a/test/test_job_persistence.py
+++ b/test/test_job_persistence.py
@@ -121,7 +121,7 @@ def test_job_persistence_transaction_online_backend(httpx_mock: HTTPXMock, tmp_p
         assert request.headers["authorization"] == f"Bearer {token}"
 
         _, workspace_id, resource_id = request.url.path.rsplit("/", maxsplit=2)
-        data = api_models.JobSubmission.model_validate_json(request.content.decode("utf-8"))
+        data = api_models.SubmitJobRequest.model_validate_json(request.content.decode("utf-8"))
         circuits = data.payload.circuits
         job_id = uuid.uuid4()
 

--- a/test/test_resource.py
+++ b/test/test_resource.py
@@ -304,7 +304,7 @@ def test_submit_payload_matches(httpx_mock: HTTPXMock) -> None:
             f"submit/{backend.resource_id.workspace_id}/{backend.resource_id.resource_id}"
         )
 
-        data = api_models.JobSubmission.model_validate_json(request.content.decode("utf-8"))
+        data = api_models.SubmitJobRequest.model_validate_json(request.content.decode("utf-8"))
         assert data == expected_job_payload
 
         return httpx.Response(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Update the client to follow the latest AQT cloud portal public API specification.

There are no structural changes to the API models. The main changes are new constraints, e.g. on the circuit size.

### Details and comments

The gate models' new description contain math code with illegal escape codes. The generated docstrings must therefore be declared as raw strings. This is done by applying the autofix for the ruff rule [D301](https://docs.astral.sh/ruff/rules/escape-sequence-in-docstring/) (`escape-sequence-in-docstring`). With some exceptions, the whole file is now linted and formatted.
