### PR TITLE
Update models according to Arnica

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* reduce gates per circuit to 2000 and circuits per batch to 50 (#181)
+
 ## qiskit-aqt-provider v1.7.0
 
 * Update API specification and associated constraints (#176)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* reduce gates per circuit to 2000 and circuits per batch to 50 (#181)
+* Reduce gates per circuit to 2000 and circuits per batch to 50 (#181)
 
 ## qiskit-aqt-provider v1.7.0
 

--- a/api/aqt_public.yml
+++ b/api/aqt_public.yml
@@ -18,7 +18,7 @@ components:
         - operation: MEASURE
       items:
         $ref: '#/components/schemas/OperationModel'
-      maxItems: 2500
+      maxItems: 2000
       minItems: 1
       title: Circuit
       type: array
@@ -45,7 +45,10 @@ components:
         operation:
           const: R
           default: R
+          enum:
+          - R
           title: Operation
+          type: string
         phi:
           maximum: 2.0
           minimum: 0.0
@@ -96,7 +99,10 @@ components:
         operation:
           const: RXX
           default: RXX
+          enum:
+          - RXX
           title: Operation
+          type: string
         qubits:
           items:
             minimum: 0.0
@@ -136,7 +142,10 @@ components:
         operation:
           const: RZ
           default: RZ
+          enum:
+          - RZ
           title: Operation
+          type: string
         phi:
           title: Phi
           type: number
@@ -231,7 +240,10 @@ components:
         job_type:
           const: quantum_circuit
           default: quantum_circuit
+          enum:
+          - quantum_circuit
           title: Job Type
+          type: string
         label:
           anyOf:
           - type: string
@@ -261,7 +273,10 @@ components:
         operation:
           const: MEASURE
           default: MEASURE
+          enum:
+          - MEASURE
           title: Operation
+          type: string
       required:
       - operation
       title: Measure
@@ -363,7 +378,10 @@ components:
         status:
           const: cancelled
           default: cancelled
+          enum:
+          - cancelled
           title: Status
+          type: string
       title: RRCancelled
       type: object
     RRError:
@@ -377,7 +395,10 @@ components:
         status:
           const: error
           default: error
+          enum:
+          - error
           title: Status
+          type: string
       required:
       - message
       title: RRError
@@ -418,7 +439,10 @@ components:
         status:
           const: finished
           default: finished
+          enum:
+          - finished
           title: Status
+          type: string
       required:
       - result
       title: RRFinished
@@ -435,7 +459,10 @@ components:
         status:
           const: ongoing
           default: ongoing
+          enum:
+          - ongoing
           title: Status
+          type: string
       required:
       - finished_count
       title: RROngoing
@@ -447,7 +474,10 @@ components:
         status:
           const: queued
           default: queued
+          enum:
+          - queued
           title: Status
+          type: string
       title: RRQueued
       type: object
     Resource:
@@ -713,7 +743,10 @@ components:
         job_type:
           const: quantum_circuit
           default: quantum_circuit
+          enum:
+          - quantum_circuit
           title: Job Type
+          type: string
         label:
           anyOf:
           - type: string
@@ -746,7 +779,10 @@ components:
         message:
           const: unknown job_id
           default: unknown job_id
+          enum:
+          - unknown job_id
           title: Message
+          type: string
       required:
       - job_id
       title: UnknownJob

--- a/qiskit_aqt_provider/api_models_generated.py
+++ b/qiskit_aqt_provider/api_models_generated.py
@@ -325,7 +325,7 @@ class Circuit(RootModel[List[OperationModel]]):
                     {"operation": "MEASURE"},
                 ]
             ],
-            max_length=2500,
+            max_length=2000,
             min_length=1,
             title="Circuit",
         ),

--- a/qiskit_aqt_provider/aqt_resource.py
+++ b/qiskit_aqt_provider/aqt_resource.py
@@ -132,7 +132,7 @@ class _ResourceBase(Generic[_OptionsType], Backend):
     @property
     def max_circuits(self) -> int:
         """Maximum number of circuits per batch."""
-        return 2000
+        return 50
 
     @property
     def target(self) -> Target:


### PR DESCRIPTION
### Summary

Update the client to follow the latest AQT cloud portal public API specification.

There are no structural changes to the API models, only changes of constraints.

### Details and comments
The limits for
- max gates per circuit
- circuits per job

were updated according to the Arnica API specification

Circuits per job was already updated a while ago, but overlooked here.
