### PR TITLE
Workflows: harden, update tooling

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,28 +1,19 @@
 name: Deploy documentation
 
 on:
-  # Runs on version tags pushes
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
   # Runs on manual triggers
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -30,14 +21,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install Poetry
         uses: abatilo/actions-poetry@v2
         with:
-          poetry-version: '1.7.1'
+          poetry-version: '1.8.3'
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: "poetry"
       - name: Check Poetry lock file consistency
         run: poetry check --lock
@@ -53,6 +46,17 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: 'docs/_build'
+
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -67,7 +67,7 @@ jobs:
           poetry run python examples/number_partition.py
         if: startsWith(matrix.os, 'windows')
       - name: Install all dependencies
-        run: poetry install --sync --extras test
+        run: poetry install --sync --all-extras
       - name: Check version numbers consistency
         run: poetry run poe version_check
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -15,10 +15,12 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
-        poetry-version: [1.7.1]
+        poetry-version: [1.8.3]
         os: ["ubuntu-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install poetry
         uses: abatilo/actions-poetry@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release Artifacts
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 jobs:
   wheel-build:
     name: Build and Publish Release Artifacts
@@ -14,14 +14,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install Poetry
         uses: abatilo/actions-poetry@v2
         with:
-          poetry-version: '1.7.1'
+          poetry-version: '1.8.3'
       - name: Install release dependencies
         run: pip install -U typer mistletoe
       - name: Build packages
@@ -33,11 +35,12 @@ jobs:
         with:
           path: ./dist/qiskit*
       - name: Extract changelog
-        run: python scripts/extract-changelog.py ${{ github.ref_name }} | tee ${{ github.workspace }}-CHANGELOG.txt
+        run: |
+          python scripts/extract-changelog.py "${{ github.ref_name }}" | tee "${{ github.workspace }}-CHANGELOG.txt"
       - name: Create Github release
         uses: softprops/action-gh-release@v1
         with:
           files: ./dist/qiskit*
-          body_path: ${{ github.workspace }}-CHANGELOG.txt
+          body_path: "${{ github.workspace }}-CHANGELOG.txt"
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,10 @@ jobs:
         shell: bash
       - name: Extract changelog
         run: |
-          python scripts/extract-changelog.py "${{ github.ref_name }}" | tee RELEASE_CHANGELOG.txt
+          python scripts/extract-changelog.py "${TAG_NAME}" | tee RELEASE_CHANGELOG.txt
+        shell: bash
+        env:
+          TAG_NAME: ${{ github.ref_name }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,10 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 jobs:
-  wheel-build:
-    name: Build and Publish Release Artifacts
-    runs-on: ubuntu-latest
+  build:
+    name: Build release artifacts
     environment: release
-    permissions:
-      id-token: write
-      contents: write
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -30,17 +27,37 @@ jobs:
         run: |
           poetry build
         shell: bash
+      - name: Extract changelog
+        run: |
+          python scripts/extract-changelog.py "${{ github.ref_name }}" | tee RELEASE_CHANGELOG.txt
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          path: ./dist/qiskit*
-      - name: Extract changelog
-        run: |
-          python scripts/extract-changelog.py "${{ github.ref_name }}" | tee "${{ github.workspace }}-CHANGELOG.txt"
+          path: |
+            ./dist/qiskit*
+            RELEASE_CHANGELOG.txt
+
+  create_release:
+    name: Create GitHub release
+    needs: build
+    environment: release
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
       - name: Create Github release
         uses: softprops/action-gh-release@v1
         with:
           files: ./dist/qiskit*
-          body_path: "${{ github.workspace }}-CHANGELOG.txt"
+          body_path: "RELEASE_CHANGELOG.txt"
+
+  deploy:
+    name: Deploy to PyPI
+    needs: build
+    environment: release
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Various workflows hardening measures, guided by [zizmor](https://github.com/woodruffw/zizmor) reports (thanks @wilfried-huss for the hint).

- use `persist-credentials: false` in `actions/checkout`. We don't use raw git commands in the steps (so none requires authentication)
- restrict the tag patterns that trigger the `docs` and `release` workflows
- for documentation and release, split the workflows into build and release jobs, such that token permissions are only given when strictly necessary
- update Poetry and Python versions in `docs` and `release`.
