### PR TITLE
Improve reporting of known API calls error scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fix issue with oversized batches on offline simulators (#210)
+* Improve reporting of known API calls error scenarios (#211)
 
 ## qiskit-aqt-provider v1.9.0
 

--- a/docs/apidoc/api_client.rst
+++ b/docs/apidoc/api_client.rst
@@ -25,3 +25,7 @@ API client
    :members:
    :show-inheritance:
    :exclude-members: __init__, __new__, model_fields, model_computed_fields, model_config
+
+.. autoclass:: qiskit_aqt_provider.api_client.errors.APIError
+   :show-inheritance:
+   :exclude-members: __init__, __new__

--- a/qiskit_aqt_provider/api_client/errors.py
+++ b/qiskit_aqt_provider/api_client/errors.py
@@ -1,0 +1,58 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright Alpine Quantum Technologies GmbH 2025
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import json
+from typing import Any
+
+import httpx
+
+
+class APIError(Exception):
+    """An API request failed.
+
+    Instances of this class are raised when errors occur while communicating
+    with the target resource API (for both remote and direct-access resources).
+
+    If the underlying API request failed with an error status, the exception chain
+    contains the original `httpx.HTTPStatusError <https://www.python-httpx.org/exceptions/#:~:text=httpx.HTTPStatusError>`_
+    """
+
+    def __init__(self, detail: Any) -> None:
+        """Initialize the exception instance.
+
+        Args:
+            detail: error description payload. The string representation is used as error message.
+        """
+        super().__init__(str(detail) if detail is not None else "Unspecified error")
+
+        # Keep the original object, in case it wasn't a string.
+        self.detail = detail
+
+
+def http_response_raise_for_status(response: httpx.Response) -> httpx.Response:
+    """Check the HTTP status of a response payload.
+
+    Returns:
+        The passed HTTP response, unchanged.
+
+    Raises:
+        APIError: the API response contains an error status.
+    """
+    try:
+        return response.raise_for_status()
+    except httpx.HTTPStatusError as status_error:
+        try:
+            detail = response.json().get("detail")
+        except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
+            detail = None
+
+        raise APIError(detail) from status_error

--- a/qiskit_aqt_provider/api_client/portal_client.py
+++ b/qiskit_aqt_provider/api_client/portal_client.py
@@ -13,6 +13,8 @@ from typing import Final, Optional
 
 import httpx
 
+from qiskit_aqt_provider.api_client.errors import http_response_raise_for_status
+
 from . import models
 from .versions import make_user_agent
 
@@ -58,10 +60,9 @@ class PortalClient:
 
         Raises:
             httpx.NetworkError: connection to the remote portal failed.
-            httpx.HTTPStatusError: something went wrong with the request to the remote portal.
+            APIError: something went wrong with the request to the remote portal.
         """
         with self._http_client as client:
-            response = client.get("/workspaces")
+            response = http_response_raise_for_status(client.get("/workspaces"))
 
-        response.raise_for_status()
         return models.Workspaces.model_validate(response.json())

--- a/qiskit_aqt_provider/aqt_job.py
+++ b/qiskit_aqt_provider/aqt_job.py
@@ -278,6 +278,7 @@ class AQTJob(JobV1):
 
         Raises:
             RuntimeError: this job was already submitted.
+            APIError: the operation failed on the remote portal.
         """
         if self.job_id():
             raise RuntimeError(f"Job already submitted (ID: {self.job_id()})")
@@ -290,6 +291,9 @@ class AQTJob(JobV1):
 
         Returns:
             Aggregated job status for all the circuits in this job.
+
+        Raises:
+            APIError: the operation failed on the remote portal.
         """
         payload = self._backend.result(uuid.UUID(self.job_id()))
 
@@ -343,6 +347,9 @@ class AQTJob(JobV1):
 
         Returns:
             The combined result of all circuit evaluations.
+
+        Raises:
+            APIError: the operation failed on the remote portal.
         """
         if self.options.with_progress_bar:
             context: Union[tqdm[NoReturn], _MockProgressBar] = tqdm(total=len(self.circuits))
@@ -438,6 +445,9 @@ class AQTDirectAccessJob(JobV1):
 
         Returns:
             The combined result of all circuit evaluations.
+
+        Raises:
+            APIError: the operation failed on the target resource.
         """
         if self.options.with_progress_bar:
             context: Union[tqdm[NoReturn], _MockProgressBar] = tqdm(total=len(self.circuits))

--- a/qiskit_aqt_provider/aqt_provider.py
+++ b/qiskit_aqt_provider/aqt_provider.py
@@ -35,6 +35,7 @@ from tabulate import tabulate
 from typing_extensions import TypeAlias, override
 
 from qiskit_aqt_provider.api_client import PortalClient, Resource, ResourceType, Workspace
+from qiskit_aqt_provider.api_client.errors import APIError
 from qiskit_aqt_provider.aqt_resource import (
     AQTDirectAccessResource,
     AQTResource,
@@ -234,7 +235,7 @@ class AQTProvider:
 
         # Only query if remote resources are requested.
         if backend_type != "offline_simulator":
-            with contextlib.suppress(httpx.HTTPError, httpx.NetworkError):
+            with contextlib.suppress(APIError, httpx.NetworkError):
                 remote_workspaces = self._portal_client.workspaces().filter(
                     name_pattern=name,
                     backend_type=backend_type if backend_type else None,

--- a/tach.toml
+++ b/tach.toml
@@ -37,6 +37,7 @@ expose = [
     "__version__",
     # There are some instances of this, although not included in __all__
     "models.*",
+    "errors.*",
 ]
 from = [
     "qiskit_aqt_provider.api_client",

--- a/test/api_client/test_errors.py
+++ b/test/api_client/test_errors.py
@@ -1,0 +1,61 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright Alpine Quantum Technologies GmbH 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+
+from contextlib import AbstractContextManager, nullcontext
+from typing import Any, Optional
+
+import httpx
+import pytest
+
+from qiskit_aqt_provider.api_client.errors import APIError, http_response_raise_for_status
+
+
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        pytest.param(httpx.Response(status_code=httpx.codes.OK), nullcontext(), id="ok"),
+        pytest.param(
+            httpx.Response(status_code=httpx.codes.INTERNAL_SERVER_ERROR),
+            pytest.raises(APIError),
+            id="error-no-detail",
+        ),
+        pytest.param(
+            httpx.Response(
+                status_code=httpx.codes.INTERNAL_SERVER_ERROR, json={"detail": "error_message"}
+            ),
+            pytest.raises(APIError, match="error_message"),
+            id="error-with-detail",
+        ),
+    ],
+)
+def test_http_response_raise_for_status(
+    response: httpx.Response, expected: AbstractContextManager[Optional[pytest.ExceptionInfo[Any]]]
+) -> None:
+    """Test the wrapper around httpx.Response.raise_for_status.
+
+    The wrapper re-packs the httpx.HTTPStatusError into a custom APIError, sets
+    the latter's message to the error detail (if available), and propagates the
+    original exception as cause for the APIError.
+    """
+    # Set dummy request (required because HTTPStatusError propagates the request).
+    response.request = httpx.Request(method="GET", url="https://example.com")
+
+    with expected as excinfo:
+        http_response_raise_for_status(response)
+
+    # Error test cases all derive from a HTTP error status.
+    # Check that the exception chain has the relevant information.
+    if excinfo is not None:
+        status_error = excinfo.value.__cause__
+        assert isinstance(status_error, httpx.HTTPStatusError)
+        assert status_error.response.status_code == response.status_code


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Improve the reporting of errors from the remote server (portal or direct-access resource) propagated through HTTP error status codes.

For example, submitting a circuit on a direct-access backend that has less ions loaded than the circuit requires physical qubits is now reported as: (modulo changes in the backend's implementation)

```
Traceback (most recent call last):
  ...
httpx.HTTPStatusError: Client error '413 Request Entity Too Large' for url 'http://localhost:3001/api/v1/circuit/'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  ...
qiskit_aqt_provider.api_client.errors.APIError: Not enough qubits: available qubits=0, requested=4
```

### Details and comments

The new `APIError` type is purposely not linked to `httpx.HTTPStatusError`, such that it can be extended to errors reported by the remote servers with success status codes (dedicated error payloads). For the moment, the interface only assumes that the `detail` object has an acceptable string representation.
