### PR TITLE
Unpin Qiskit, upgrade to 1.3.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3361,22 +3361,21 @@ cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "qiskit"
-version = "1.2.4"
+version = "1.3.1"
 description = "An open-source SDK for working with quantum computers at the level of extended quantum circuits, operators, and primitives."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "qiskit-1.2.4-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:1cdabddeed74956ac22db8b11b3479044a305b0895b142198f11a75e745aa079"},
-    {file = "qiskit-1.2.4-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9daad1c3a0608c4a32a03112d0650cc51ced2cab16479703230acedafafa0548"},
-    {file = "qiskit-1.2.4-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:3394ec724adeb481c02b050ac6e5929ca5e1f91ab94a1d571dadf0c702d6967e"},
-    {file = "qiskit-1.2.4-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:124777b0d9caf40932e02d1d2c6be3a12ff058990e6ae55f45a315a9a51da75b"},
-    {file = "qiskit-1.2.4-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2c8d9fa7fdb0cf7727f27a1881cc9f9be7de2b6aaf7cab6861686e1a6e34d6c8"},
-    {file = "qiskit-1.2.4-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a973089d54f379006df8ae9b0d406e909e02b11a9390b3e2f50aefd5e8070eb"},
-    {file = "qiskit-1.2.4-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:409b43d48e33e5bbc316fd85f44f29a71db2d5ff802affabc5ee355fe9573d7e"},
-    {file = "qiskit-1.2.4-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a66303ab4f939080ca0b8c4102040a89417a99f2621978c7bca8b1d5f6c6e103"},
-    {file = "qiskit-1.2.4-cp38-abi3-win32.whl", hash = "sha256:93aa20398c5ab79adb4baf89a76d034a7c608fcc5bcbbd77355314378583e56a"},
-    {file = "qiskit-1.2.4-cp38-abi3-win_amd64.whl", hash = "sha256:87175e179bbaa3d2e280f14fe90efa77d6d7521d58ee5afd9528ec6716a6d8e6"},
-    {file = "qiskit-1.2.4.tar.gz", hash = "sha256:3f30b1fc6c66dec240428991da75cc6c35cc75152baff8daf3f8ca71b60684e8"},
+    {file = "qiskit-1.3.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:78ce80685e187dff53a824ca27891c5860ee989f28e3da9ef6c356e40e39ef35"},
+    {file = "qiskit-1.3.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:c1406190aab851468873c185c4f19d00e842dad8d17bd674acd52d9d5185f162"},
+    {file = "qiskit-1.3.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67f33bcc5df7367bc68a69e890be8cddd16f2f15c3a60fa745a7437df9408493"},
+    {file = "qiskit-1.3.1-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8f121d5c4872f68d1e11b0a8a7cb6823112c126e774b296405e36d3202e47ba6"},
+    {file = "qiskit-1.3.1-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0fa3c46263a22b40bdbaace361104ac202f9af119f333a1fc45fce6f4c7bb066"},
+    {file = "qiskit-1.3.1-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5f8d1f5a6616fd95d05f838b47c9b744f635733f085574465da09090dfa819b6"},
+    {file = "qiskit-1.3.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:644edc9b47c2f99d2654cca12e1a41bf51ce3dabfaddb0c1895b1ca32d790b35"},
+    {file = "qiskit-1.3.1-cp39-abi3-win32.whl", hash = "sha256:7a20969ec5595df37f7944f186fcae7b8b0e91dcc6f6da313b4a99587276bf45"},
+    {file = "qiskit-1.3.1-cp39-abi3-win_amd64.whl", hash = "sha256:8c26c7e1134b18764ec50049596b5abe572737c99e6e88fb65d4e01bd8e85806"},
+    {file = "qiskit-1.3.1.tar.gz", hash = "sha256:7c9b34d700175db6615c9ab150b86f6f06ff7b74540e50bdf2ec7dc904639385"},
 ]
 
 [package.dependencies]
@@ -4799,4 +4798,4 @@ test = ["pytest", "pytest-httpx", "pytest-mock", "pytest-sugar"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "db7d11a5c8bd09230b252fe842666ed0206ef8ae7f05069ce40d813c335cd973"
+content-hash = "786f5fe993cf41a67f8350995ae44b058ad8493728f68e07da743ef1d205a399"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3361,21 +3361,18 @@ cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "qiskit"
-version = "1.3.1"
+version = "1.3.2"
 description = "An open-source SDK for working with quantum computers at the level of extended quantum circuits, operators, and primitives."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "qiskit-1.3.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:78ce80685e187dff53a824ca27891c5860ee989f28e3da9ef6c356e40e39ef35"},
-    {file = "qiskit-1.3.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:c1406190aab851468873c185c4f19d00e842dad8d17bd674acd52d9d5185f162"},
-    {file = "qiskit-1.3.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67f33bcc5df7367bc68a69e890be8cddd16f2f15c3a60fa745a7437df9408493"},
-    {file = "qiskit-1.3.1-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8f121d5c4872f68d1e11b0a8a7cb6823112c126e774b296405e36d3202e47ba6"},
-    {file = "qiskit-1.3.1-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0fa3c46263a22b40bdbaace361104ac202f9af119f333a1fc45fce6f4c7bb066"},
-    {file = "qiskit-1.3.1-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5f8d1f5a6616fd95d05f838b47c9b744f635733f085574465da09090dfa819b6"},
-    {file = "qiskit-1.3.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:644edc9b47c2f99d2654cca12e1a41bf51ce3dabfaddb0c1895b1ca32d790b35"},
-    {file = "qiskit-1.3.1-cp39-abi3-win32.whl", hash = "sha256:7a20969ec5595df37f7944f186fcae7b8b0e91dcc6f6da313b4a99587276bf45"},
-    {file = "qiskit-1.3.1-cp39-abi3-win_amd64.whl", hash = "sha256:8c26c7e1134b18764ec50049596b5abe572737c99e6e88fb65d4e01bd8e85806"},
-    {file = "qiskit-1.3.1.tar.gz", hash = "sha256:7c9b34d700175db6615c9ab150b86f6f06ff7b74540e50bdf2ec7dc904639385"},
+    {file = "qiskit-1.3.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:3fe16377787e31c67b87b2baa9fe3239ffab46e1697ed7dfc4687f89f283453b"},
+    {file = "qiskit-1.3.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:fc7be685e0f144825201da4c818e370977ab1be07049587899b209beca48a39e"},
+    {file = "qiskit-1.3.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:65d5af561b6e0e98b099fe4b7bf099dcd1f09322fa1d47299ba2b2febc873ec7"},
+    {file = "qiskit-1.3.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309f6db004ea8044df9ac9359c31dcce0cc12afb6ece6eb035ca86b9bf87a21c"},
+    {file = "qiskit-1.3.2-cp39-abi3-win32.whl", hash = "sha256:113a6962b3cd79a0aeeee92072a3e808291e776d8ca7ab25dffaea2e0c288b8d"},
+    {file = "qiskit-1.3.2-cp39-abi3-win_amd64.whl", hash = "sha256:8ec122c81f832c1a9202dae6485d402d1444845be2c53809f10d82cb1423e735"},
+    {file = "qiskit-1.3.2.tar.gz", hash = "sha256:6e63c619bcc3e29cd59f831af5b161b35951498c272d00da01a3fef7db3743c9"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ pytest-httpx = { version = "^0.34.0", optional = true }
 pytest-mock = { version = "^3.11.1", optional = true }
 pytest-sugar = { version = "^1.0.0", optional = true }
 python-dotenv = ">=1"
-qiskit = "^1,<1.3"
+qiskit = "^1"
 qiskit-aer = ">=0.13.2"
 qiskit-algorithms = { version = ">=0.2.1", optional = true }
 qiskit-optimization = { version = ">=0.6.0", optional = true }

--- a/qiskit_aqt_provider/test/circuits.py
+++ b/qiskit_aqt_provider/test/circuits.py
@@ -40,7 +40,7 @@ def assert_circuits_equal_ignore_global_phase(
 def assert_circuits_equivalent(result: QuantumCircuit, expected: QuantumCircuit) -> None:
     """Assert that the passed circuits are equivalent up to a global phase."""
     msg = f"\nexpected:\n{expected}\nresult:\n{result}"
-    assert Operator(expected).equiv(Operator(result)), msg  # noqa: S101
+    assert Operator.from_circuit(expected).equiv(Operator.from_circuit(result)), msg  # noqa: S101
 
 
 def empty_circuit(num_qubits: int, with_final_measurement: bool = True) -> QuantumCircuit:

--- a/test/test_circuit_to_aqt.py
+++ b/test/test_circuit_to_aqt.py
@@ -32,7 +32,6 @@ from qiskit_aqt_provider.test.circuits import (
     qft_circuit,
     random_circuit,
 )
-from qiskit_aqt_provider.versions import QISKIT_VERSION
 
 
 def test_no_circuit() -> None:
@@ -215,11 +214,7 @@ def test_convert_multiple_circuits() -> None:
         pytest.param(random_circuit(2, with_final_measurement=False), id="random-2"),
         pytest.param(random_circuit(3, with_final_measurement=False), id="random-3"),
         pytest.param(random_circuit(5, with_final_measurement=False), id="random-5"),
-        pytest.param(
-            qft_circuit(5),
-            id="qft-5",
-            marks=pytest.mark.xfail(QISKIT_VERSION >= "1.3", reason="See qiskit/qiskit#13693"),
-        ),
+        pytest.param(qft_circuit(5), id="qft-5"),
     ],
 )
 def test_convert_circuit_round_trip(

--- a/test/test_circuit_to_aqt.py
+++ b/test/test_circuit_to_aqt.py
@@ -32,6 +32,7 @@ from qiskit_aqt_provider.test.circuits import (
     qft_circuit,
     random_circuit,
 )
+from qiskit_aqt_provider.versions import QISKIT_VERSION
 
 
 def test_no_circuit() -> None:
@@ -214,7 +215,11 @@ def test_convert_multiple_circuits() -> None:
         pytest.param(random_circuit(2, with_final_measurement=False), id="random-2"),
         pytest.param(random_circuit(3, with_final_measurement=False), id="random-3"),
         pytest.param(random_circuit(5, with_final_measurement=False), id="random-5"),
-        pytest.param(qft_circuit(5), id="qft-5"),
+        pytest.param(
+            qft_circuit(5),
+            id="qft-5",
+            marks=pytest.mark.xfail(QISKIT_VERSION >= "1.3", reason="See qiskit/qiskit#13693"),
+        ),
     ],
 )
 def test_convert_circuit_round_trip(

--- a/test/test_execution.py
+++ b/test/test_execution.py
@@ -394,9 +394,7 @@ def test_initialize_not_supported(offline_simulator_no_noise: AQTResource) -> No
 
     with pytest.raises(
         TranspilerError,
-        match=re.compile(
-            r"high\s?level\s?synthesis was unable to synthesize instruction", re.IGNORECASE
-        ),
+        match=re.compile(r"unable to translate the operations in the circuit", re.IGNORECASE),
     ):
         qiskit.transpile(qc, offline_simulator_no_noise)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Upgrade the locked Qiskit dependency to 1.3.2. Undo the pin added in #204.

Resolves #205.

### Details and comments

There are some changes when transpiling circuits that contain SWAP gates, which includes the example QFT circuit. If any, issues are to be addressed on the Qiskit side. See Qiskit/qiskit#13693. ~~Meanwhile, we just xfail the corresponding test. Random circuits should be sufficient to test round-tripping through the portal representation.~~ The test case is re-enabled using an improved version of the circuit equivalence assertion.

The error message when transpilation fails was unified as part of Qiskit/qiskit#13237.