### PR TITLE
Replace tach-external with deptry

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -67,7 +67,7 @@ disallow_subclassing_any = False
 # other modules to import them. When false, mypy will not re-export unless the item
 # is imported using from-as or is included in __all__.
 # Note that mypy treats stub files as if this is always disabled.
-implicit_reexport = True
+implicit_reexport = False
 
 # Use an SQLite database to store the cache.
 sqlite_cache = False

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,8 +37,10 @@ repos:
     rev: "v0.27.3"
     hooks:
       - id: tach
-      - id: tach-external
-        args: ["-e", "test/"]
+  - repo: https://github.com/fpgmaas/deptry
+    rev: "0.23.0"
+    hooks:
+      - id: deptry
   - repo: local
     hooks:
       - id: check-api-models

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add support for Python 3.13 (#187)
+* Remove `pytest-mock` and `pytest-sugar` from the `test` dependencies group (#219)
 
 ## qiskit-aqt-provider v1.10.0
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -821,6 +821,38 @@ files = [
 ]
 
 [[package]]
+name = "deptry"
+version = "0.23.0"
+description = "A command line utility to check for unused, missing and transitive dependencies in a Python project."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "deptry-0.23.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:1f2a6817a37d76e8f6b667381b7caf6ea3e6d6c18b5be24d36c625f387c79852"},
+    {file = "deptry-0.23.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:9601b64cc0aed42687fdd5c912d5f1e90d7f7333fb589b14e35bfdfebae866f3"},
+    {file = "deptry-0.23.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6172b2205f6e84bcc9df25226693d4deb9576a6f746c2ace828f6d13401d357"},
+    {file = "deptry-0.23.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1cfa4b3a46ee8a026eaa38e4b9ba43fe6036a07fe16bf0a663cb611b939f6af8"},
+    {file = "deptry-0.23.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:9d03cc99a61c348df92074a50e0a71b28f264f0edbf686084ca90e6fd44e3abe"},
+    {file = "deptry-0.23.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:9a46f78098f145100dc582a59af8548b26cdfa16cf0fbd85d2d44645e724cb6a"},
+    {file = "deptry-0.23.0-cp39-abi3-win_amd64.whl", hash = "sha256:d53e803b280791d89a051b6183d9dc40411200e22a8ab7e6c32c6b169822a664"},
+    {file = "deptry-0.23.0-cp39-abi3-win_arm64.whl", hash = "sha256:da7678624f4626d839c8c03675452cefc59d6cf57d25c84a9711dae514719279"},
+    {file = "deptry-0.23.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:40706dcbed54141f2d23afa70a272171c8c46531cd6f0f9c8ef482c906b3cee2"},
+    {file = "deptry-0.23.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:889541844092f18e7b48631852195f36c25c5afd4d7e074b19ba824b430add50"},
+    {file = "deptry-0.23.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aff9156228eb16cd81792f920c1623c00cb59091ae572600ba0eac587da33c0c"},
+    {file = "deptry-0.23.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:583154732cfd438a4a090b7d13d8b2016f1ac2732534f34fb689345768d8538b"},
+    {file = "deptry-0.23.0-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:736e7bc557aec6118b2a4d454f0d81f070782faeaa9d8d3c9a15985c9f265372"},
+    {file = "deptry-0.23.0-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:5f7e4b1a5232ed6d352fca7173750610a169377d1951d3e9782947191942a765"},
+    {file = "deptry-0.23.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:04afae204654542406318fd3dd6f4a6697579597f37195437daf84a53ee0ebbf"},
+    {file = "deptry-0.23.0.tar.gz", hash = "sha256:4915a3590ccf38ad7a9176aee376745aa9de121f50f8da8fb9ccec87fa93e676"},
+]
+
+[package.dependencies]
+click = ">=8.0.0,<9"
+colorama = {version = ">=0.4.6", markers = "sys_platform == \"win32\""}
+packaging = ">=23.2"
+requirements-parser = ">=0.11.0,<1"
+tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
+
+[[package]]
 name = "dict2css"
 version = "0.3.0.post1"
 description = "A μ-library for constructing cascading style sheets from Python dictionaries."
@@ -3567,6 +3599,21 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "requirements-parser"
+version = "0.11.0"
+description = "This is a small Python module for parsing Pip requirement files."
+optional = false
+python-versions = "<4.0,>=3.8"
+files = [
+    {file = "requirements_parser-0.11.0-py3-none-any.whl", hash = "sha256:50379eb50311834386c2568263ae5225d7b9d0867fb55cf4ecc93959de2c2684"},
+    {file = "requirements_parser-0.11.0.tar.gz", hash = "sha256:35f36dc969d14830bf459803da84f314dc3d17c802592e9e970f63d0359e5920"},
+]
+
+[package.dependencies]
+packaging = ">=23.2"
+types-setuptools = ">=69.1.0"
+
+[[package]]
 name = "rich"
 version = "13.9.4"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
@@ -4645,17 +4692,6 @@ shellingham = ">=1.3.0"
 typing-extensions = ">=3.7.4.3"
 
 [[package]]
-name = "types-docutils"
-version = "0.21.0.20241128"
-description = "Typing stubs for docutils"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "types_docutils-0.21.0.20241128-py3-none-any.whl", hash = "sha256:e0409204009639e9b0bf4521eeabe58b5e574ce9c0db08421c2ac26c32be0039"},
-    {file = "types_docutils-0.21.0.20241128.tar.gz", hash = "sha256:4dd059805b83ac6ec5a223699195c4e9eeb0446a4f7f2aeff1759a4a7cc17473"},
-]
-
-[[package]]
 name = "types-requests"
 version = "2.32.0.20250306"
 description = "Typing stubs for requests"
@@ -4671,17 +4707,17 @@ urllib3 = ">=2"
 
 [[package]]
 name = "types-setuptools"
-version = "65.7.0.4"
+version = "75.8.2.20250305"
 description = "Typing stubs for setuptools"
 optional = false
-python-versions = "*"
+python-versions = ">=3.9"
 files = [
-    {file = "types-setuptools-65.7.0.4.tar.gz", hash = "sha256:147809433301fe7e0f4ef5c0782f9a0453788960575e1efb6da5fe8cb2493c9f"},
-    {file = "types_setuptools-65.7.0.4-py3-none-any.whl", hash = "sha256:522067dfd8e1771f8d7e047e451de2740dc4e0c9f48a22302a6cc96e6c964a13"},
+    {file = "types_setuptools-75.8.2.20250305-py3-none-any.whl", hash = "sha256:ba80953fd1f5f49e552285c024f75b5223096a38a5138a54d18ddd3fa8f6a2d4"},
+    {file = "types_setuptools-75.8.2.20250305.tar.gz", hash = "sha256:a987269b49488f21961a1d99aa8d281b611625883def6392a93855b31544e405"},
 ]
 
 [package.dependencies]
-types-docutils = "*"
+setuptools = "*"
 
 [[package]]
 name = "types-tabulate"
@@ -4876,4 +4912,4 @@ test = ["pytest", "pytest-httpx", "pytest-mock", "pytest-sugar"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.14"
-content-hash = "7d69247b9b94d04798dcee541e97ad3a316b1b02d1e42d1f514cbe1eb9920111"
+content-hash = "c57b53134ea2356ff954ab3748f8dc770a5f436e6394edab401bc3f42412b411"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1356,7 +1356,7 @@ testing = ["pygments", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdo
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
@@ -2684,7 +2684,7 @@ type = ["mypy (>=1.11.2)"]
 name = "pluggy"
 version = "1.5.0"
 description = "plugin and hook calling mechanisms for python"
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
@@ -3087,7 +3087,7 @@ toml-fmt-common = "1.0.1"
 name = "pytest"
 version = "8.3.5"
 description = "pytest: simple powerful testing with Python"
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820"},
@@ -3127,7 +3127,7 @@ testing = ["pytest-asyncio (==0.24.*)", "pytest-cov (==5.*)"]
 name = "pytest-mock"
 version = "3.14.0"
 description = "Thin-wrapper around the mock package for easier use with pytest"
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
@@ -3144,7 +3144,7 @@ dev = ["pre-commit", "pytest-asyncio", "tox"]
 name = "pytest-sugar"
 version = "1.0.0"
 description = "pytest-sugar is a plugin for pytest that changes the default look and feel of pytest (e.g. progressbar, show tests that fail instantly)."
-optional = true
+optional = false
 python-versions = "*"
 files = [
     {file = "pytest-sugar-1.0.0.tar.gz", hash = "sha256:6422e83258f5b0c04ce7c632176c7732cab5fdb909cb39cca5c9139f81276c0a"},
@@ -4513,7 +4513,7 @@ dev = ["build (==1.1.1)", "build (==1.2.1)", "coverage (==7.2.7)", "coverage (==
 name = "termcolor"
 version = "2.5.0"
 description = "ANSI color formatting for output in terminal"
-optional = true
+optional = false
 python-versions = ">=3.9"
 files = [
     {file = "termcolor-2.5.0-py3-none-any.whl", hash = "sha256:37b17b5fc1e604945c2642c872a3764b5d547a48009871aea3edd3afa180afb8"},
@@ -4907,9 +4907,9 @@ type = ["pytest-mypy"]
 
 [extras]
 examples = ["qiskit-algorithms", "qiskit-optimization"]
-test = ["pytest", "pytest-httpx", "pytest-mock", "pytest-sugar"]
+test = ["pytest", "pytest-httpx"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.14"
-content-hash = "c57b53134ea2356ff954ab3748f8dc770a5f436e6394edab401bc3f42412b411"
+content-hash = "223457130017585582c8d98528b24223d307fbd34efa7a7e6ce0d88903e2790b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4912,4 +4912,4 @@ test = ["pytest", "pytest-httpx"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.14"
-content-hash = "223457130017585582c8d98528b24223d307fbd34efa7a7e6ce0d88903e2790b"
+content-hash = "67f4578ddc007124e30ccd39afa9da8191b9689afbc7617164629d0e70ed14be"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,6 @@ platformdirs = ">=3"
 pydantic = ">=2.5.0"
 pytest = { version = ">=8", optional = true }
 pytest-httpx = { version = "^0.34.0", optional = true }
-pytest-mock = { version = "^3.11.1", optional = true }
-pytest-sugar = { version = "^1.0.0", optional = true }
 python-dotenv = ">=1"
 qiskit = "^1"
 qiskit-aer = ">=0.13.2"
@@ -102,6 +100,8 @@ mistletoe = "^1.1.0"
 mypy = "^1.14.0"
 poethepoet = "^0.32.0"
 polyfactory = "^2.0.0"
+pytest-mock = "^3"
+pytest-sugar = "^1"
 pre-commit = "^3.1.1"
 pyproject-fmt = "^2.1.3"
 qiskit-sphinx-theme = ">=1.16.1"
@@ -123,15 +123,15 @@ typos = "^1.29.0"
 yq = "^3.4.3"
 
 [tool.poetry.extras]
+# Dependencies for the example scripts.
 examples = [
   "qiskit-algorithms",
   "qiskit-optimization",
 ]
+# Dependencies for the pytest plugin.
 test = [
   "pytest",
   "pytest-httpx",
-  "pytest-mock",
-  "pytest-sugar",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ annotated-types = ">=0.7.0"
 httpx = ">=0.24.0"
 platformdirs = ">=3"
 pydantic = ">=2.5.0"
+pydantic-core = ">=2"
 pytest = { version = ">=8", optional = true }
 pytest-httpx = { version = "^0.34.0", optional = true }
 python-dotenv = ">=1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ numpy = [
 autodoc-pydantic = "^2.0.1"
 coverage = "^7.2.1"
 datamodel-code-generator = "^0.28.0"
+deptry = "^0.23.0"
 hypothesis = "^6.82.0"
 interrogate = "^1.5.0"
 ipykernel = "^6.22.0"
@@ -115,7 +116,7 @@ tach = "^0.27.0"
 tomlkit = "^0.13.2"
 typer = "^0.15.0"
 types-requests = "^2.28.11"
-types-setuptools = "^65.7.0"
+types-setuptools = ">=65.7.0"
 types-tabulate = "^0.9.0.1"
 types-tqdm = "^4.65.0.1"
 typos = "^1.29.0"
@@ -218,6 +219,9 @@ lint.per-file-ignores."test/**/*.py" = [
   "S101",    # allow assertions
 ]
 lint.pydocstyle.convention = "google"
+
+[tool.deptry]
+extend_exclude = [ "scripts", "test", "conftest.py" ]
 
 [tool.coverage.run]
 dynamic_context = "test_function"
@@ -336,7 +340,7 @@ shell = "tach check"
 [tool.poe.tasks.check_external_dependencies]
 # Exclude the test module because tach doesn't collect
 # dependencies outside the main group.
-shell = "tach check-external -e test/"
+shell = "deptry ."
 
 [tool.poe.tasks]
 lint = [

--- a/qiskit_aqt_provider/persistence.py
+++ b/qiskit_aqt_provider/persistence.py
@@ -19,7 +19,7 @@ from typing import Any, Optional, Union
 import platformdirs
 import pydantic as pdt
 from pydantic import ConfigDict, GetCoreSchemaHandler
-from pydantic_core import CoreSchema, core_schema
+from pydantic.types import CoreSchema, core_schema
 from qiskit import qpy
 from qiskit.circuit import QuantumCircuit
 from typing_extensions import Self

--- a/qiskit_aqt_provider/persistence.py
+++ b/qiskit_aqt_provider/persistence.py
@@ -19,7 +19,7 @@ from typing import Any, Optional, Union
 import platformdirs
 import pydantic as pdt
 from pydantic import ConfigDict, GetCoreSchemaHandler
-from pydantic.types import CoreSchema, core_schema
+from pydantic_core import CoreSchema, core_schema
 from qiskit import qpy
 from qiskit.circuit import QuantumCircuit
 from typing_extensions import Self

--- a/scripts/check_pre_commit_consistency.sh
+++ b/scripts/check_pre_commit_consistency.sh
@@ -19,7 +19,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 readonly SCRIPT_DIR
 
 # Tools to check.
-TOOLS=(ruff typos pyproject-fmt interrogate tach)
+TOOLS=(ruff typos pyproject-fmt interrogate tach deptry)
 readonly TOOLS
 
 # Entry point: check version consistency for all tools in TOOLS.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Replace `tach`'s external dependencies check with [deptry](https://deptry.com), which has a more comprehensive set of rules.

### Details

The check only affects non-testing dependencies and only covers the code in the shipped package (i.e. under `qiskit_aqt_provider/`). Testing dependencies are not covered by `deptry`'s extraction logic (see [here](https://deptry.com/usage/#dependencies-extraction)).

Dependencies that are only required for the pytest plugin are listed in the `test` dependencies group. This is unchanged. However:
- `pytest-mock` is not used by the plugin (this is enforced by `deptry`). `pytest-sugar` is not strictly required,  and only  affects the overall pytest behavior, which we don't want to implicitly influence when registering the plugin in 3rd-party projects. Both are moved to regular development dependencies.
- `deptry` currently cannot check that dependencies in the `test` group are only used on a given sub-package / module, i.e. `deptry`  would not flag a `pytest` import in e.g. `aqt_job.py`. This is not a regression compared to `tach check-external`.

`pydantic_core` is a transitive dependency of `pydantic` that we need to import from to modify the `core_schema`. This is [documented behavior](https://docs.pydantic.dev/2.10/concepts/types/#customizing-validation-with-__get_pydantic_core_schema__). Since [`DEP003`](https://deptry.com/rules-violations/#transitive-dependencies-dep003) forbids the use of transitive dependencies, we have to explicitly depend on `pydantic_core`. The exact dependency resolution is left to the package manager, assuming that the compatibility bounds in `pydantic` and `pydantic_core` are correct.

Fly-by: disable `mypy`'s [`implicit_reexport`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-implicit_reexport), since it doesn't create issues.
