### PR TITLE
Fix outdated AQT website link in the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add support for Python 3.13 (#187)
 * Remove `pytest-mock` and `pytest-sugar` from the `test` dependencies group (#219)
+* Fix outdated AQT website link in the docs (#221)
 
 ## qiskit-aqt-provider v1.10.0
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,5 +79,5 @@ For more details see the :ref:`user guide <user-guide>`, a selection of `example
   :caption: External links
 
   Repository <https://github.com/qiskit-community/qiskit-aqt-provider>
-  AQT <https://www.aqt.eu/qc-systems>
+  AQT <https://www.aqt.eu/products/arnica>
   API reference <https://arnica.aqt.eu/api/v1/docs>


### PR DESCRIPTION
### Summary
The link to the AQT website in the docs is outdated. This sets the correct URL.


### Details and comments
Outdated URL: https://www.aqt.eu/qc-systems
Correct URL: https://www.aqt.eu/products/arnica