### PR TITLE
Fetch the number of qubits per resource from the portal API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Configure resources transpilation targets with the actual number of available qubits (#237)
+
 ## qiskit-aqt-provider v1.12.0
 * Point Qiskit docs links to quantum.cloud.ibm.com/docs (#229)
 * Match the gate sets used by the transpilation target and the API (#226)

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -87,13 +87,22 @@ Direct-access backends
 
 Direct-access resources handles are obtained from a provider using the :meth:`get_direct_access_backend <qiskit_aqt_provider.aqt_provider.AQTProvider.get_direct_access_backend>` method:
 
-.. jupyter-execute::
+.. code-block:: python
 
    direct_access_backend = provider.get_direct_access_backend("http://URL")
 
 Contact your local system administrator to determine the exact base URL to access your local quantum computing system.
 
 .. tip:: Resources handles returned by :meth:`get_backend <qiskit_aqt_provider.aqt_provider.AQTProvider.get_backend>` and :meth:`get_direct_access_backend <qiskit_aqt_provider.aqt_provider.AQTProvider.get_direct_access_backend>` both implement the Qiskit :class:`BackendV2 <qiskit.providers.BackendV2>` interface can be used exchangeably in the following examples.
+
+Quantum register size
+=====================
+
+The number of qubits available on a given resource may vary. This is because the number of ions loaded in an AQT quantum computing resource is adjustable. All-to-all connectivity is always guaranteed, independently of the number of available qubits.
+
+The number of qubits available for remote and direct-access resources cannot be configured with this provider. For offline simulator, the `available_qubits` argument in :meth:`get_backend <qiskit_aqt_provider.aqt_provider.AQTProvider.get_backend>` can be used to set the size of the simulated quantum register. By default, offline simulator are configured with 20 qubits.
+
+.. warning:: For remote and direct-access resources, the number of qubits is fetched from the resource when initializing the resource handle, i.e. when calling :meth:`get_backend <qiskit_aqt_provider.aqt_provider.AQTProvider.get_backend>`. Subsequent transpilation calls will assume that at least this number of qubits is available.
 
 Quantum circuit evaluation
 ==========================

--- a/qiskit_aqt_provider/api_client/models.py
+++ b/qiskit_aqt_provider/api_client/models.py
@@ -176,7 +176,7 @@ class Workspaces(
 
         .. code-block::
 
-            | Workspace ID | Resource ID | Resource Type | Qubits |
+            | Workspace ID | Resource ID | Resource Type | Available Qubits |
             |--------------+-------------+---------------|--------|
             | workspace0   | resource0   | device        |     10 |
             | workspace1   | resource0   | device        |     20 |

--- a/qiskit_aqt_provider/api_client/models.py
+++ b/qiskit_aqt_provider/api_client/models.py
@@ -100,6 +100,9 @@ class Resource(pdt.BaseModel):
     resource_type: ResourceType
     """Type of resource."""
 
+    available_qubits: int
+    """Number of qubits jobs on this resource can use."""
+
 
 class Workspace(pdt.BaseModel):
     """Description of a workspace and the resources it contains.
@@ -116,6 +119,14 @@ class Workspace(pdt.BaseModel):
     """Resources in the workspace."""
 
 
+class ApiWorkspaces(
+    pdt.RootModel  # type: ignore[type-arg]
+):
+    """List of available workspaces and devices, in API format."""
+
+    root: list[api_models.Workspace]
+
+
 class Workspaces(
     pdt.RootModel,  # type: ignore[type-arg]
     Collection[Workspace],
@@ -125,28 +136,34 @@ class Workspaces(
     ..
         >>> workspaces = Workspaces(
         ...     root=[
-        ...         api_models.Workspace(
-        ...             id="workspace0",
+        ...         Workspace(
+        ...             workspace_id="workspace0",
         ...             resources=[
-        ...                 api_models.Resource(
-        ...                     id="resource0",
-        ...                     name="resource0",
-        ...                     type=api_models.Type.device,
+        ...                 Resource(
+        ...                     workspace_id="workspace0",
+        ...                     resource_id="resource0",
+        ...                     resource_name="resource0",
+        ...                     resource_type="device",
+        ...                     available_qubits=10,
         ...                 ),
         ...             ],
         ...         ),
-        ...        api_models.Workspace(
-        ...            id="workspace1",
+        ...        Workspace(
+        ...            workspace_id="workspace1",
         ...            resources=[
-        ...                api_models.Resource(
-        ...                    id="resource0",
-        ...                    name="resource0",
-        ...                    type=api_models.Type.device,
+        ...                Resource(
+        ...                    workspace_id="workspace1",
+        ...                    resource_id="resource0",
+        ...                    resource_name="resource0",
+        ...                    resource_type="device",
+        ...                    available_qubits=20,
         ...                ),
-        ...                api_models.Resource(
-        ...                    id="resource1",
-        ...                    name="resource1",
-        ...                    type=api_models.Type.simulator,
+        ...                Resource(
+        ...                    workspace_id="workspace1",
+        ...                    resource_id="resource1",
+        ...                    resource_name="resource1",
+        ...                    resource_type="simulator",
+        ...                    available_qubits=12,
         ...                ),
         ...            ],
         ...        ),
@@ -159,11 +176,11 @@ class Workspaces(
 
         .. code-block::
 
-            | Workspace ID | Resource ID | Resource Type |
-            |--------------+-------------+---------------|
-            | workspace0   | resource0   | device        |
-            | workspace1   | resource0   | device        |
-            | workspace1   | resource1   | simulator     |
+            | Workspace ID | Resource ID | Resource Type | Qubits |
+            |--------------+-------------+---------------|--------|
+            | workspace0   | resource0   | device        |     10 |
+            | workspace1   | resource0   | device        |     20 |
+            | workspace1   | resource1   | simulator     |     12 |
 
         Gather basic information:
 
@@ -192,7 +209,7 @@ class Workspaces(
         [('workspace0', 'resource0'), ('workspace1', 'resource0')]
     """
 
-    root: list[api_models.Workspace]
+    root: list[Workspace]
 
     @override
     def __len__(self) -> int:
@@ -202,19 +219,7 @@ class Workspaces(
     @override
     def __iter__(self) -> Iterator[Workspace]:  # type: ignore[override]
         """Iterator over the workspaces."""
-        for ws in self.root:
-            yield Workspace(
-                workspace_id=ws.id,
-                resources=[
-                    Resource(
-                        workspace_id=ws.id,
-                        resource_id=res.id,
-                        resource_name=res.name,
-                        resource_type=res.type.value,
-                    )
-                    for res in ws.resources
-                ],
-            )
+        yield from self.root
 
     @override
     def __contains__(self, obj: object) -> bool:
@@ -222,7 +227,7 @@ class Workspaces(
         if not isinstance(obj, Workspace):  # pragma: no cover
             return False
 
-        return any(ws.id == obj.workspace_id for ws in self.root)
+        return any(ws.workspace_id == obj.workspace_id for ws in self.root)
 
     def filter(
         self,
@@ -245,22 +250,24 @@ class Workspaces(
         """
         filtered_workspaces = []
         for workspace in self.root:
-            if workspace_pattern is not None and not re.match(workspace_pattern, workspace.id):
+            if workspace_pattern is not None and not re.match(
+                workspace_pattern, workspace.workspace_id
+            ):
                 continue
 
             filtered_resources = []
 
             for resource in workspace.resources:
-                if backend_type is not None and resource.type.value != backend_type:
+                if backend_type is not None and resource.resource_type != backend_type:
                     continue
 
-                if name_pattern is not None and not re.match(name_pattern, resource.id):
+                if name_pattern is not None and not re.match(name_pattern, resource.resource_id):
                     continue
 
                 filtered_resources.append(resource)
 
             filtered_workspaces.append(
-                api_models.Workspace(id=workspace.id, resources=filtered_resources)
+                Workspace(workspace_id=workspace.workspace_id, resources=filtered_resources)
             )
 
         return self.__class__(root=filtered_workspaces)

--- a/qiskit_aqt_provider/api_client/models_direct.py
+++ b/qiskit_aqt_provider/api_client/models_direct.py
@@ -19,6 +19,13 @@ import pydantic as pdt
 from typing_extensions import Self
 
 
+class NumIons(pdt.BaseModel):
+    """Response model for the `GET /status/ions` query."""
+
+    num_ions: int
+    """Number of ions loaded on the direct-access resource."""
+
+
 class JobResultError(pdt.BaseModel):
     """Failed job result payload."""
 

--- a/qiskit_aqt_provider/aqt_provider.py
+++ b/qiskit_aqt_provider/aqt_provider.py
@@ -93,7 +93,7 @@ class BackendsTable(Sequence[AQTResource]):
             "Resource ID",
             "Description",
             "Resource type",
-            "Available Qubits",
+            "Available qubits",
         ]
 
     @overload

--- a/qiskit_aqt_provider/aqt_provider.py
+++ b/qiskit_aqt_provider/aqt_provider.py
@@ -30,7 +30,9 @@ from typing import (
 
 import dotenv
 import httpx
+from qiskit.exceptions import QiskitError
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
+from qiskit.transpiler import Target
 from tabulate import tabulate
 from typing_extensions import TypeAlias, override
 
@@ -40,6 +42,7 @@ from qiskit_aqt_provider.aqt_resource import (
     AQTDirectAccessResource,
     AQTResource,
     OfflineSimulatorResource,
+    make_transpiler_target,
 )
 from qiskit_aqt_provider.versions import USER_AGENT_EXTRA
 
@@ -85,7 +88,13 @@ class BackendsTable(Sequence[AQTResource]):
             backends: list of available backends.
         """
         self.backends = backends
-        self.headers = ["Workspace ID", "Resource ID", "Description", "Resource type"]
+        self.headers = [
+            "Workspace ID",
+            "Resource ID",
+            "Description",
+            "Resource type",
+            "Available Qubits",
+        ]
 
     @overload
     def __getitem__(self, index: int) -> AQTResource: ...
@@ -133,6 +142,7 @@ class BackendsTable(Sequence[AQTResource]):
                     resource.resource_id.resource_id,
                     resource.resource_id.resource_name,
                     resource.resource_id.resource_type,
+                    resource.target.num_qubits,
                 ]
                 if count != 0:
                     # don't repeat the workspace id
@@ -259,6 +269,7 @@ class AQTProvider:
                             resource_id=simulator.id,
                             resource_name=simulator.name,
                             resource_type="offline_simulator",
+                            available_qubits=20,
                         ),
                         with_noise_model=simulator.noisy,
                     )
@@ -283,6 +294,7 @@ class AQTProvider:
         *,
         backend_type: Optional[ResourceType] = None,
         workspace: Optional[Union[str, Pattern[str]]] = None,
+        available_qubits: Optional[int] = None,
     ) -> AQTResource:
         """Return a handle for a cloud quantum computing resource matching the specified filtering.
 
@@ -290,6 +302,8 @@ class AQTProvider:
             name: filter for the backend name.
             backend_type: if given, restrict the search to the given backend type.
             workspace: if given, restrict to matching workspace IDs.
+            available_qubits: only valid for ``offline_simulator``-type backends. If given,
+              set the size of the quantum register to simulate.
 
         Returns:
             Backend: backend matching the filtering.
@@ -302,12 +316,22 @@ class AQTProvider:
         # after ProviderV1 deprecation.
         # See: https://github.com/Qiskit/qiskit/pull/12145.
         backends = self.backends(name, backend_type=backend_type, workspace=workspace)
-        if len(backends) > 1:
+        if len(backends) > 1:  # pragma: no cover
             raise QiskitBackendNotFoundError("More than one backend matches the criteria")
-        if not backends:
+        if not backends:  # pragma: no cover
             raise QiskitBackendNotFoundError("No backend matches the criteria")
 
-        return backends[0]
+        selected_backend = backends[0]
+
+        if available_qubits is not None:
+            if not isinstance(selected_backend, OfflineSimulatorResource):
+                raise QiskitError(
+                    "available_qubits can only be used when selecting an offline simulator"
+                )
+
+            selected_backend._target = make_transpiler_target(Target, available_qubits)
+
+        return selected_backend
 
     def get_direct_access_backend(self, base_url: str, /) -> AQTDirectAccessResource:
         """Return a handle for a direct-access quantum computing resource.

--- a/qiskit_aqt_provider/test/fixtures.py
+++ b/qiskit_aqt_provider/test/fixtures.py
@@ -54,6 +54,7 @@ class MockSimulator(OfflineSimulatorResource):
                 resource_id="mock_simulator",
                 resource_name="mock_simulator",
                 resource_type="offline_simulator",
+                available_qubits=20,
             ),
             with_noise_model=noisy,
         )
@@ -134,6 +135,10 @@ def fixture_offline_simulator_no_noise_direct_access(
     httpx_mock.add_callback(handle_submit, method="PUT", url=re.compile(".+/circuit/?$"))
     httpx_mock.add_callback(
         handle_result, method="GET", url=re.compile(".+/circuit/result/[0-9a-f-]+$")
+    )
+    httpx_mock.add_response(
+        json=json.loads(api_models_direct.NumIons(num_ions=21).model_dump_json()),
+        url=re.compile(".+/status/ions"),
     )
 
     return DummyDirectAccessResource("token")

--- a/qiskit_aqt_provider/test/resources.py
+++ b/qiskit_aqt_provider/test/resources.py
@@ -157,6 +157,7 @@ class TestResource(AQTResource):  # pylint: disable=too-many-instance-attributes
                 resource_id="test",
                 resource_name="test-resource",
                 resource_type="simulator",
+                available_qubits=20,
             ),
         )
 
@@ -228,6 +229,7 @@ class DummyResource(AQTResource):
                 resource_id="dummy",
                 resource_name="dummy",
                 resource_type="simulator",
+                available_qubits=20,
             ),
         )
 
@@ -239,5 +241,5 @@ class DummyDirectAccessResource(AQTDirectAccessResource):
         """Initialize the dummy backend."""
         super().__init__(
             AQTProvider(token),
-            base_url="direct-access-example.aqt.eu:6020",
+            base_url="https://direct-access-example.aqt.eu:6020",
         )

--- a/qiskit_aqt_provider/test/resources.py
+++ b/qiskit_aqt_provider/test/resources.py
@@ -241,5 +241,5 @@ class DummyDirectAccessResource(AQTDirectAccessResource):
         """Initialize the dummy backend."""
         super().__init__(
             AQTProvider(token),
-            base_url="https://direct-access-example.aqt.eu:6020",
+            base_url="http://direct-access-example.aqt.eu:6020",
         )

--- a/test/api_client/test_models.py
+++ b/test/api_client/test_models.py
@@ -13,7 +13,6 @@
 import pytest
 
 from qiskit_aqt_provider.api_client import models as api_models
-from qiskit_aqt_provider.api_client import models_generated as api_models_generated
 
 
 def test_workspaces_container_empty() -> None:
@@ -31,7 +30,7 @@ def test_workspaces_contains() -> None:
     """Test the Workspaces.__contains__ implementation."""
     workspaces = api_models.Workspaces(
         root=[
-            api_models_generated.Workspace(id="w1", resources=[]),
+            api_models.Workspace(workspace_id="w1", resources=[]),
         ]
     )
 
@@ -43,8 +42,8 @@ def test_workspaces_filter_by_workspace() -> None:
     """Test filtering the Workspaces model content by workspace ID."""
     workspaces = api_models.Workspaces(
         root=[
-            api_models_generated.Workspace(id="w1", resources=[]),
-            api_models_generated.Workspace(id="w2", resources=[]),
+            api_models.Workspace(workspace_id="w1", resources=[]),
+            api_models.Workspace(workspace_id="w2", resources=[]),
         ]
     )
 
@@ -59,22 +58,34 @@ def test_workspaces_filter_by_name() -> None:
     """Test filtering the Workspaces model content by backend ID."""
     workspaces = api_models.Workspaces(
         root=[
-            api_models_generated.Workspace(
-                id="w1",
+            api_models.Workspace(
+                workspace_id="w1",
                 resources=[
-                    api_models_generated.Resource(
-                        id="r10", name="r10", type=api_models_generated.Type.device
+                    api_models.Resource(
+                        workspace_id="w1",
+                        resource_id="r10",
+                        resource_name="r10",
+                        resource_type="device",
+                        available_qubits=20,
                     ),
-                    api_models_generated.Resource(
-                        id="r20", name="r20", type=api_models_generated.Type.device
+                    api_models.Resource(
+                        workspace_id="w1",
+                        resource_id="r20",
+                        resource_name="r20",
+                        resource_type="device",
+                        available_qubits=20,
                     ),
                 ],
             ),
-            api_models_generated.Workspace(
-                id="w2",
+            api_models.Workspace(
+                workspace_id="w2",
                 resources=[
-                    api_models_generated.Resource(
-                        id="r11", name="r11", type=api_models_generated.Type.simulator
+                    api_models.Resource(
+                        workspace_id="w2",
+                        resource_id="r11",
+                        resource_name="r11",
+                        resource_type="simulator",
+                        available_qubits=20,
                     )
                 ],
             ),
@@ -85,19 +96,27 @@ def test_workspaces_filter_by_name() -> None:
 
     assert filtered == api_models.Workspaces(
         root=[
-            api_models_generated.Workspace(
-                id="w1",
+            api_models.Workspace(
+                workspace_id="w1",
                 resources=[
-                    api_models_generated.Resource(
-                        id="r10", name="r10", type=api_models_generated.Type.device
+                    api_models.Resource(
+                        workspace_id="w1",
+                        resource_id="r10",
+                        resource_name="r10",
+                        resource_type="device",
+                        available_qubits=20,
                     ),
                 ],
             ),
-            api_models_generated.Workspace(
-                id="w2",
+            api_models.Workspace(
+                workspace_id="w2",
                 resources=[
-                    api_models_generated.Resource(
-                        id="r11", name="r11", type=api_models_generated.Type.simulator
+                    api_models.Resource(
+                        workspace_id="w2",
+                        resource_id="r11",
+                        resource_name="r11",
+                        resource_type="simulator",
+                        available_qubits=20,
                     )
                 ],
             ),
@@ -109,14 +128,22 @@ def test_workspaces_filter_by_backend_type() -> None:
     """Test filtering the Workspaces model content by backend type."""
     workspaces = api_models.Workspaces(
         root=[
-            api_models_generated.Workspace(
-                id="w1",
+            api_models.Workspace(
+                workspace_id="w1",
                 resources=[
-                    api_models_generated.Resource(
-                        id="r1", name="r1", type=api_models_generated.Type.device
+                    api_models.Resource(
+                        workspace_id="w1",
+                        resource_id="r1",
+                        resource_name="r1",
+                        resource_type="device",
+                        available_qubits=20,
                     ),
-                    api_models_generated.Resource(
-                        id="r2", name="r2", type=api_models_generated.Type.simulator
+                    api_models.Resource(
+                        workspace_id="w1",
+                        resource_id="r2",
+                        resource_name="r2",
+                        resource_type="simulator",
+                        available_qubits=20,
                     ),
                 ],
             )
@@ -129,7 +156,11 @@ def test_workspaces_filter_by_backend_type() -> None:
         workspace_id="w1",
         resources=[
             api_models.Resource(
-                workspace_id="w1", resource_id="r2", resource_name="r2", resource_type="simulator"
+                workspace_id="w1",
+                resource_id="r2",
+                resource_name="r2",
+                resource_type="simulator",
+                available_qubits=20,
             )
         ],
     )

--- a/test/test_job_persistence.py
+++ b/test/test_job_persistence.py
@@ -103,6 +103,7 @@ def test_job_persistence_transaction_online_backend(httpx_mock: HTTPXMock, tmp_p
         resource_id=str(uuid.uuid4()),
         resource_name=str(uuid.uuid4()),
         resource_type="device",
+        available_qubits=32,
     )
     backend = AQTResource(provider, resource_id)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fetch the number of qubits of remote and direct-access resources when initializing the resource handle.

Resolves #232.

### Details and comments

This patch makes sure that the transpilation target for given resource matches (to the used properties so far) the current configuration of the remote / direct-access resource.

The number of qubits is fetched only once per lifetime of the resource handle. This limits execution overhead, assuming that the number of qubits doesn't change too often.