### PR TITLE
Prepare release v1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+
+## qiskit-aqt-provider v1.15.0
+
 * Use aqt-connector models (#248)
 * Update aqt-connector to 0.3.0 (#251)
 * Unify user experience to acquire backends accessed via cloud or directly (#256)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,9 @@ copyright = "2023, Qiskit and AQT development teams"
 author = "Qiskit and AQT development teams"
 
 # The short X.Y version
-version = "1.14.0"
+version = "1.15.0"
 # The full version, including alpha/beta/rc tags
-release = "1.14.0"
+release = "1.15.0"
 
 extensions = [
     "sphinx.ext.napoleon",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "qiskit-aqt-provider"
-version = "1.14.0"
+version = "1.15.0"
 description = "Qiskit provider for AQT backends"
 authors = [
   "Qiskit Development Team",


### PR DESCRIPTION
### Summary
Prepares release 1.15.0

### Details and comments
* Use aqt-connector models (#248)
* Update aqt-connector to 0.3.0 (#251)
* Unify user experience to acquire backends accessed via cloud or directly (#256)
* Add hint to docs regarding token expiration, remove token from examples (#260)