### PR TITLE
Publish v1 docs to /v1 path

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Deploy documentation
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v1.[0-9]+.[0-9]+'
 
   # Runs on manual triggers
   workflow_dispatch:
@@ -18,6 +18,7 @@ jobs:
       contents: write
     env:
       DOCS_DEFAULT_VERSION: ${{ vars.DOCS_DEFAULT_VERSION }}
+      DOCS_VERSION_PATH: v1
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -41,18 +42,30 @@ jobs:
         run: poetry run poe version_check
       - name: Build documentation
         run: poetry run poe docs
-      - name: Stage docs under v1
+      - name: Publish versioned docs to gh-pages
         run: |
-          tmpdir="$(mktemp -d)"
-          mv docs/_build "${tmpdir}/site"
-          mkdir -p docs/_build/v1
-          cp -a "${tmpdir}/site/." docs/_build/v1/
-          rm -rf "${tmpdir}"
-      - name: Create docs landing page
-        run: |
+          remote_url="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
+          workdir="$(mktemp -d)"
+
+          git init "${workdir}"
+          cd "${workdir}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git ls-remote --exit-code --heads "${remote_url}" gh-pages > /dev/null 2>&1; then
+            git fetch --depth=1 "${remote_url}" gh-pages
+            git checkout -B gh-pages FETCH_HEAD
+          else
+            git checkout --orphan gh-pages
+          fi
+
           : "${DOCS_DEFAULT_VERSION:?Set repository variable DOCS_DEFAULT_VERSION}"
-          mkdir -p docs/_build
-          cat > docs/_build/index.html <<EOF
+
+          rm -rf "${DOCS_VERSION_PATH}"
+          mkdir -p "${DOCS_VERSION_PATH}"
+          cp -a "${GITHUB_WORKSPACE}/docs/_build/." "${DOCS_VERSION_PATH}/"
+
+          cat > index.html <<EOF
           <!doctype html>
           <html lang="en">
           <head>
@@ -70,9 +83,13 @@ jobs:
           </body>
           </html>
           EOF
-      - name: Publish documentation to gh-pages branch
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/_build
-          keep_files: true
+
+          touch .nojekyll
+          git add --all
+          if git diff --cached --quiet; then
+            echo "No documentation changes to publish."
+            exit 0
+          fi
+
+          git commit -m "Deploy ${DOCS_VERSION_PATH} docs for ${GITHUB_REF_NAME}"
+          git push "${remote_url}" gh-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,9 +14,10 @@ concurrency:
 
 jobs:
   build:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      contents: write
+    env:
+      DOCS_DEFAULT_VERSION: ${{ vars.DOCS_DEFAULT_VERSION }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -40,23 +41,38 @@ jobs:
         run: poetry run poe version_check
       - name: Build documentation
         run: poetry run poe docs
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Stage docs under v1
+        run: |
+          tmpdir="$(mktemp -d)"
+          mv docs/_build "${tmpdir}/site"
+          mkdir -p docs/_build/v1
+          cp -a "${tmpdir}/site/." docs/_build/v1/
+          rm -rf "${tmpdir}"
+      - name: Create docs landing page
+        run: |
+          : "${DOCS_DEFAULT_VERSION:?Set repository variable DOCS_DEFAULT_VERSION}"
+          mkdir -p docs/_build
+          cat > docs/_build/index.html <<EOF
+          <!doctype html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <meta http-equiv="refresh" content="0; url=./${DOCS_DEFAULT_VERSION}/">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <link rel="canonical" href="./${DOCS_DEFAULT_VERSION}/">
+            <title>Qiskit AQT Provider documentation</title>
+            <script>
+              window.location.replace("./${DOCS_DEFAULT_VERSION}/");
+            </script>
+          </head>
+          <body>
+            <p>Redirecting to <a href="./${DOCS_DEFAULT_VERSION}/">default documentation</a>.</p>
+          </body>
+          </html>
+          EOF
+      - name: Publish documentation to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: 'docs/_build'
-
-  deploy:
-    needs: build
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_build
+          keep_files: true


### PR DESCRIPTION
### Summary

Publishes v1 docs under /v1/ path.

### Details and comments

Changes the job publishing workflow to publish the v1 docs under the path /v1/ instead of at the root. This allows room to keep the legacy docs online whilst adding the v2 docs alongside. An actions variable is used to define the current default.