### PR TITLE
Add guard against forks triggering release

### DIFF
--- a/.github/workflows/publish_release_v2.yml
+++ b/.github/workflows/publish_release_v2.yml
@@ -18,7 +18,10 @@ env:
 jobs:
   preflight:
     name: release preflight
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.metadata.outputs.version }}


### PR DESCRIPTION
Adds a guard to the v2 publish workflow to prevent repository forks triggering it with arbitrary code.

I've manually disabled the workflow in the meantime so it can't happen...