### PR TITLE
Add dedicated v2 release environment

### DIFF
--- a/.github/workflows/publish_release_v2.yml
+++ b/.github/workflows/publish_release_v2.yml
@@ -205,7 +205,7 @@ jobs:
   release:
     name: publish release
     runs-on: ubuntu-latest
-    environment: release
+    environment: release-v2
     needs: [preflight, acceptance]
     permissions:
       id-token: write


### PR DESCRIPTION
Changed the deployment environment from `release` to `release-v2` in the `.github/workflows/publish_release_v2.yml`  workflow.