### PR TITLE
Reorder v2 release workflow

### DIFF
--- a/.github/workflows/publish_release_v2.yml
+++ b/.github/workflows/publish_release_v2.yml
@@ -16,6 +16,84 @@ env:
   TARGET_PYTHON: ${{ vars.TARGET_PYTHON }}
 
 jobs:
+  build:
+    name: build release distributions
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Set up Python ${{ env.TARGET_PYTHON }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.TARGET_PYTHON }}
+
+      - name: Install uv ${{ env.UV_VERSION }}
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install mise
+        uses: jdx/mise-action@v2
+
+      - name: Install all dependencies
+        run: uv sync --all-groups --extra test
+
+      - name: Build release distributions
+        run: mise run build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  acceptance:
+    name: test release distributions
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Set up Python ${{ env.TARGET_PYTHON }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.TARGET_PYTHON }}
+
+      - name: Install uv ${{ env.UV_VERSION }}
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install mise
+        uses: jdx/mise-action@v2
+
+      - name: Install test dependencies
+        run: uv sync --group lint --extra test --no-install-project
+
+      - name: Download release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Install release distribution
+        shell: bash
+        run: |
+          ls -lah dist
+          test -n "$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
+          uv pip install dist/*.whl
+
+      - name: Run acceptance tests
+        run: mise run test:acceptance
+
   preflight:
     name: release preflight
     if: >
@@ -23,6 +101,7 @@ jobs:
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
+    needs: acceptance
     outputs:
       version: ${{ steps.metadata.outputs.version }}
       tag: ${{ steps.metadata.outputs.tag }}
@@ -127,83 +206,11 @@ jobs:
           name: release-changelog
           path: RELEASE_CHANGELOG.txt
 
-  build:
-    name: build release distributions
-    runs-on: ubuntu-latest
-    needs: preflight
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-
-      - name: Set up Python ${{ env.TARGET_PYTHON }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.TARGET_PYTHON }}
-
-      - name: Install uv ${{ env.UV_VERSION }}
-        uses: astral-sh/setup-uv@v5
-        with:
-          version: ${{ env.UV_VERSION }}
-
-      - name: Install mise
-        uses: jdx/mise-action@v2
-
-      - name: Install all dependencies
-        run: uv sync --all-groups --extra test
-
-      - name: Build release distributions
-        run: mise run build
-
-      - name: Upload distributions
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-dists
-          path: dist/
-
-  acceptance:
-    name: test release distributions
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-
-      - name: Set up Python ${{ env.TARGET_PYTHON }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.TARGET_PYTHON }}
-
-      - name: Install uv ${{ env.UV_VERSION }}
-        uses: astral-sh/setup-uv@v5
-        with:
-          version: ${{ env.UV_VERSION }}
-
-      - name: Install mise
-        uses: jdx/mise-action@v2
-
-      - name: Install test dependencies
-        run: uv sync --group lint --extra test --no-install-project
-
-      - name: Download release distributions
-        uses: actions/download-artifact@v4
-        with:
-          name: release-dists
-          path: dist/
-
-      - name: Install release distribution
-        shell: bash
-        run: |
-          ls -lah dist
-          test -n "$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
-          uv pip install dist/*.whl
-
-      - name: Run acceptance tests
-        run: mise run test:acceptance
-
   release:
     name: publish release
+    if: >
+      needs.preflight.outputs.should_publish == 'true' ||
+      needs.preflight.outputs.should_create_release == 'true'
     runs-on: ubuntu-latest
     environment: release-v2
     needs: [preflight, acceptance]


### PR DESCRIPTION
Reorders the v2 release workflow so it happens in a more logical/understandable order.

Also skips the release job entirely if a release shouldn't be published to either target.